### PR TITLE
[FP-76] Employees Make Widgets

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -54,6 +54,8 @@
     },
     "omnisharp.useModernNet": false,
     "cSpell.words": [
+        "Behaviour",
+        "Pathfinding",
         "Rigidbody"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -52,5 +52,8 @@
         "temp/":true,
         "Temp/":true
     },
-    "omnisharp.useModernNet": false
+    "omnisharp.useModernNet": false,
+    "cSpell.words": [
+        "Rigidbody"
+    ]
 }

--- a/Assets/PathFinder.cs
+++ b/Assets/PathFinder.cs
@@ -49,6 +49,18 @@ public static class PathFinder
 	    current.cost = 0;
 	
 	    BreadCrumb finish = new BreadCrumb(end);
+
+        if (current == null)
+        {
+            Debug.Log("current is null");
+            return null;
+        }
+        else if (current.position == null)
+        {
+            Debug.Log("current.position is null");
+            return null;
+        }
+
 	    brWorld[current.position.X, current.position.Y] = current;
 	    openList.Add(current);
 	

--- a/Assets/Pathfinding.cs
+++ b/Assets/Pathfinding.cs
@@ -296,46 +296,46 @@ public class Pathfinding : MonoBehaviour
 	void Update()
 	{
 		//Pathfinding demo
-		if (Input.GetMouseButtonDown(0))
-		{
-			//Convert mouse click point to grid coordinates
-			var mousePosition = Input.mousePosition;
-			var desiredPosition = Camera.main.ScreenToWorldPoint(new Vector3(mousePosition.x, mousePosition.y, 10.0f));
-			//Vector2 worldPos = Camera.main.ScreenToWorldPoint(Input.mousePosition);
-			//Debug.Log(desiredPosition);
-			Point gridPos = WorldToGrid(desiredPosition);			
+		// if (Input.GetMouseButtonDown(0))
+		// {
+		// 	//Convert mouse click point to grid coordinates
+		// 	var mousePosition = Input.mousePosition;
+		// 	var desiredPosition = Camera.main.ScreenToWorldPoint(new Vector3(mousePosition.x, mousePosition.y, 10.0f));
+		// 	//Vector2 worldPos = Camera.main.ScreenToWorldPoint(Input.mousePosition);
+		// 	//Debug.Log(desiredPosition);
+		// 	Point gridPos = WorldToGrid(desiredPosition);			
 
-			if (gridPos != null)
-			{
-				Nodes[gridPos.X, gridPos.Y].SetColor(Color.green);
+		// 	if (gridPos != null)
+		// 	{
+		// 		Nodes[gridPos.X, gridPos.Y].SetColor(Color.green);
 
-				if (gridPos.X > 0 && gridPos.Y > 0 && gridPos.X < Width && gridPos.Y < Height)
-				{
+		// 		if (gridPos.X > 0 && gridPos.Y > 0 && gridPos.X < Width && gridPos.Y < Height)
+		// 		{
 
-					//Convert player point to grid coordinates
-					Point playerPos = WorldToGrid(EmployeeSpawn.transform.position);
-					Nodes[playerPos.X, playerPos.Y].SetColor(Color.blue);
+		// 			//Convert player point to grid coordinates
+		// 			Point playerPos = WorldToGrid(EmployeeSpawn.transform.position);
+		// 			Nodes[playerPos.X, playerPos.Y].SetColor(Color.blue);
 
-					//Find path from player to clicked position
-					BreadCrumb bc = PathFinder.FindPath(this, playerPos, gridPos);
+		// 			//Find path from player to clicked position
+		// 			BreadCrumb bc = PathFinder.FindPath(this, playerPos, gridPos);
 
-					int count = 0;
-					LineRenderer lr = EmployeeSpawn.GetComponent<LineRenderer>();
-					lr.SetVertexCount(100);  //Need a higher number than 2, or crashes out
-					lr.SetWidth(0.1f, 0.1f);
-					lr.SetColors(Color.yellow, Color.yellow);
+		// 			int count = 0;
+		// 			LineRenderer lr = EmployeeSpawn.GetComponent<LineRenderer>();
+		// 			lr.SetVertexCount(100);  //Need a higher number than 2, or crashes out
+		// 			lr.SetWidth(0.1f, 0.1f);
+		// 			lr.SetColors(Color.yellow, Color.yellow);
 
-					//Draw out our path
-					while (bc != null)
-					{
-						lr.SetPosition(count, Pathfinding.GridToWorld(bc.position));
-						bc = bc.next;
-						count += 1;
-					}
-					lr.SetVertexCount(count);
-				}
-			}
-		}
+		// 			//Draw out our path
+		// 			while (bc != null)
+		// 			{
+		// 				lr.SetPosition(count, Pathfinding.GridToWorld(bc.position));
+		// 				bc = bc.next;
+		// 				count += 1;
+		// 			}
+		// 			lr.SetVertexCount(count);
+		// 		}
+		// 	}
+		// }
 	}
 
 }

--- a/Assets/Resources/Node.prefab
+++ b/Assets/Resources/Node.prefab
@@ -39,7 +39,7 @@ SpriteRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 163108}
-  m_Enabled: 1
+  m_Enabled: 0
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 705507994}
-  m_IndirectSpecularColor: {r: 0.44657815, g: 0.49641192, b: 0.57481617, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657844, g: 0.49641222, b: 0.57481694, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -299,7 +299,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 217011369}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 2, y: -2, z: 0}
+  m_LocalPosition: {x: 5, y: -5, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
@@ -482,6 +482,7 @@ GameObject:
   - component: {fileID: 353345060}
   - component: {fileID: 353345059}
   - component: {fileID: 353345061}
+  - component: {fileID: 353345062}
   m_Layer: 0
   m_Name: Obstacle
   m_TagString: Wall
@@ -561,7 +562,7 @@ BoxCollider2D:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 353345058}
-  m_Enabled: 1
+  m_Enabled: 0
   m_Density: 1
   m_Material: {fileID: 0}
   m_IsTrigger: 0
@@ -580,6 +581,22 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 0.16, y: 0.14230165}
   m_EdgeRadius: 0
+--- !u!70 &353345062
+CapsuleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 353345058}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_Size: {x: 0.16, y: 0.14}
+  m_Direction: 0
 --- !u!1 &404328680
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 705507994}
-  m_IndirectSpecularColor: {r: 0.44657844, g: 0.49641222, b: 0.57481694, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657815, g: 0.49641192, b: 0.57481617, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -317,7 +317,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8dbf33ce3ade49c4e95de1e93446b9bd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  target: {fileID: 1908726006}
+  target: {fileID: 0}
   speed: 10
 --- !u!1 &286385293
 GameObject:
@@ -1351,7 +1351,7 @@ Transform:
   - {fileID: 404328681}
   - {fileID: 685450272}
   m_Father: {fileID: 0}
-  m_RootOrder: 6
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1029232326
 GameObject:
@@ -1639,7 +1639,7 @@ RectTransform:
   - {fileID: 315663394}
   - {fileID: 1362908476}
   m_Father: {fileID: 0}
-  m_RootOrder: 4
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -1704,7 +1704,7 @@ Transform:
   m_LocalScale: {x: 100, y: 100, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 7
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1601859019
 GameObject:
@@ -2160,88 +2160,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1887519736}
   m_CullTransparentMesh: 1
---- !u!1 &1908726003
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1908726006}
-  - component: {fileID: 1908726004}
-  m_Layer: 0
-  m_Name: EmployeeClockInPoint
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!212 &1908726004
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1908726003}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
-  m_Color: {r: 0.30768645, g: 1, b: 0.07075471, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 0.16, y: 0.16}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
---- !u!4 &1908726006
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1908726003}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 5.78, y: -5.11, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2045675241
 GameObject:
   m_ObjectHideFlags: 0
@@ -2306,5 +2224,5 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 5
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Scripts/Actors/Employee.cs
+++ b/Assets/Scripts/Actors/Employee.cs
@@ -4,8 +4,12 @@ using UnityEngine.UI;
 
 public class Employee : IActor
 {
+    private const int WORK_START_TIME = 8;
+    private const int WORK_QUIT_TIME = 17;
+
     private GameObject guiListItem;
     private GameObject avatar;
+    private GameObject workInProgressWidget;
 
     public Guid Id
     {
@@ -51,10 +55,15 @@ public class Employee : IActor
         switch (Status)
         {
             case EmployeeStatus.WorkingPlanning:
-                WorkPlanningActivity(currentTime);
+                WorkingActivity(currentTime);
+                WorkPlanningActivity();
                 break;
             case EmployeeStatus.OffWork:
                 OffWorkActivity(currentTime);
+                break;
+            case EmployeeStatus.WorkingBuilding:
+                WorkingActivity(currentTime);
+                WorkBuildingActivity();
                 break;
             default:
                 throw new NotImplementedException("Employee status invalid.");
@@ -63,7 +72,7 @@ public class Employee : IActor
 
     public bool Active()
     {
-        return Status == EmployeeStatus.AtWork;
+        return Status == EmployeeStatus.WorkingPlanning;
     }
 
     private void OffWorkActivity(DateTime currentTime)
@@ -77,28 +86,53 @@ public class Employee : IActor
         {
             // It's a weekday.
             // Go to work at 8 AM.
-            if (currentTime.Hour >= 8 && currentTime.Hour < 17)
+            if (currentTime.Hour >= WORK_START_TIME && currentTime.Hour < WORK_QUIT_TIME)
             {
-                SetStatus(EmployeeStatus.AtWork);
+                SetStatus(EmployeeStatus.WorkingPlanning);
             }
         }
     }
 
-    private void WorkPlanningActivity(DateTime currentTime)
+    private void WorkingActivity(DateTime currentTime)
     {
-        // 5 PM is quittin' time.
-        if (currentTime.Hour >= 17)
+        if (currentTime.Hour >= WORK_QUIT_TIME)
         {
             SetStatus(EmployeeStatus.OffWork);
             return;
         }
+    }
 
-        
+    private void WorkPlanningActivity()
+    {
+        workInProgressWidget = new GameObject($"Widget WIP");
+        workInProgressWidget.transform.SetParent(avatar.transform);
+        SetStatus(EmployeeStatus.WorkingBuilding);
+    }
+
+    private void WorkBuildingActivity()
+    {
+
     }
 
     private void SetStatus(EmployeeStatus status)
     {
+        var activeAvatar = status == EmployeeStatus.WorkingPlanning;
+        avatar.SetActive(activeAvatar);
+
         this.Status = status;
+        var statusText = status.ToString();
+        if (status == EmployeeStatus.WorkingPlanning)
+        {
+            statusText = "Working - Planning";
+        } else if (status == EmployeeStatus.OffWork)
+        {
+            statusText = "Off Work";
+        }
+        else if (status == EmployeeStatus.WorkingBuilding)
+        {
+            statusText = "Working - Building";
+        }
+        
         guiListItem.transform.Find("Status").GetComponent<Text>().text = Status.ToString();
     }
 }

--- a/Assets/Scripts/Actors/Employee.cs
+++ b/Assets/Scripts/Actors/Employee.cs
@@ -50,8 +50,8 @@ public class Employee : IActor
     {
         switch (Status)
         {
-            case EmployeeStatus.AtWork:
-                AtWorkActivity(currentTime);
+            case EmployeeStatus.WorkingPlanning:
+                WorkPlanningActivity(currentTime);
                 break;
             case EmployeeStatus.OffWork:
                 OffWorkActivity(currentTime);
@@ -84,13 +84,16 @@ public class Employee : IActor
         }
     }
 
-    private void AtWorkActivity(DateTime currentTime)
+    private void WorkPlanningActivity(DateTime currentTime)
     {
         // 5 PM is quittin' time.
         if (currentTime.Hour >= 17)
         {
             SetStatus(EmployeeStatus.OffWork);
+            return;
         }
+
+        
     }
 
     private void SetStatus(EmployeeStatus status)

--- a/Assets/Scripts/Actors/Employee.cs
+++ b/Assets/Scripts/Actors/Employee.cs
@@ -48,6 +48,10 @@ public class Employee : IActor
         var avatarSpriteRenderer = avatar.GetComponent<SpriteRenderer>();
         avatarSpriteRenderer.sprite = Resources.Load<Sprite>("Circle");
         avatarSpriteRenderer.color = avatarColor;
+        avatar.AddComponent<CircleCollider2D>();
+        var collider = avatar.GetComponent<CircleCollider2D>();
+        collider.radius = 1f;
+        avatar.AddComponent<Rigidbody2D>();
     }
 
     public void Act(DateTime currentTime)
@@ -108,22 +112,15 @@ public class Employee : IActor
         if (workInProgressWidget == null)
         {
             workInProgressWidget = new GameObject($"Widget WIP");
-            workInProgressWidget.transform.SetParent(avatar.transform);
             workInProgressWidget.transform.position = (Vector2)avatar.transform.position + (Vector2)UnityEngine.Random.insideUnitCircle * 5;
-            workInProgressWidget.AddComponent<BoxCollider2D>();
-            var collider = workInProgressWidget.GetComponent<BoxCollider2D>();
-            var validSpot = collider.OverlapCollider(new ContactFilter2D(), new Collider2D[1]) == 0;
-            if (validSpot)
-            {
-                workInProgressWidget.AddComponent<SpriteRenderer>();
-                var wipWidgetSpriteRenderer = workInProgressWidget.GetComponent<SpriteRenderer>();
-                wipWidgetSpriteRenderer.sprite = Resources.Load<Sprite>("Circle");
-            }
-            else
-            {
-                UnityEngine.Object.Destroy(workInProgressWidget);
-                workInProgressWidget = null;
-            }
+            workInProgressWidget.transform.localScale = new Vector3(.2f, .2f, 1f);
+            workInProgressWidget.AddComponent<CircleCollider2D>();
+            var collider = workInProgressWidget.GetComponent<CircleCollider2D>();
+            collider.radius = 1f;
+            workInProgressWidget.AddComponent<Rigidbody2D>();
+            workInProgressWidget.AddComponent<SpriteRenderer>();
+            var wipWidgetSpriteRenderer = workInProgressWidget.GetComponent<SpriteRenderer>();
+            wipWidgetSpriteRenderer.sprite = Resources.Load<Sprite>("Circle");
         }
         else
         {
@@ -133,7 +130,11 @@ public class Employee : IActor
 
     private void WorkBuildingActivity()
     {
-        
+        // am I close enough to build?
+        var myPosition = (Vector2)avatar.transform.position;
+        var widgetPosition = (Vector2)workInProgressWidget.transform.position;
+        var distanceToWidget = Vector2.Distance(myPosition, widgetPosition);
+        Debug.Log(distanceToWidget);
     }
 
     private void SetStatus(EmployeeStatus status)

--- a/Assets/Scripts/Actors/Employee.cs
+++ b/Assets/Scripts/Actors/Employee.cs
@@ -244,6 +244,6 @@ public class Employee : IActor
             statusText = "Working - Building";
         }
         
-        guiListItem.transform.Find("Status").GetComponent<Text>().text = Status.ToString();
+        guiListItem.transform.Find("Status").GetComponent<Text>().text = statusText;
     }
 }

--- a/Assets/Scripts/Actors/EmployeeStatus.cs
+++ b/Assets/Scripts/Actors/EmployeeStatus.cs
@@ -1,5 +1,9 @@
+using System;
+
 public enum EmployeeStatus
 {
+    [Obsolete]
     AtWork,
-    OffWork
+    OffWork,
+    WorkingPlanning,
 }

--- a/Assets/Scripts/Actors/EmployeeStatus.cs
+++ b/Assets/Scripts/Actors/EmployeeStatus.cs
@@ -2,8 +2,7 @@ using System;
 
 public enum EmployeeStatus
 {
-    [Obsolete]
-    AtWork,
     OffWork,
     WorkingPlanning,
+    WorkingBuilding,
 }

--- a/Assets/Scripts/MoveToward.cs
+++ b/Assets/Scripts/MoveToward.cs
@@ -1,0 +1,27 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class MoveToward : MonoBehaviour
+{
+    public BreadCrumb breadCrumb;
+
+    void FixedUpdate()
+    {
+        if (breadCrumb == null)
+        {
+            return;
+        }
+
+        var desiredPosition = Pathfinding.GridToWorld(breadCrumb.position);
+        var distanceToPosition = Vector2.Distance(transform.position, desiredPosition);
+        if (distanceToPosition <= .25f)
+        {
+            breadCrumb = breadCrumb.next;
+        }
+        else
+        {
+            transform.position = Vector2.MoveTowards(transform.position, desiredPosition, 1f * Time.deltaTime);
+        }
+    }
+}

--- a/Assets/Scripts/MoveToward.cs.meta
+++ b/Assets/Scripts/MoveToward.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1facdabd534af4645a2122d1373065af
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
https://finalparsec.atlassian.net/browse/FP-76

Employees now have their work time split into two statuses: planning and building. During planning, they will create a new game object to represent a widget in a random location. During building, they will walk to the widget and incrementally turn it black. After "completing" a widget (completely black), they will repeat the process to make another.

Minor changes bundled in here:
- Some safety / null checks in pathfinding to keep it from crashing.
- Remove the pathfinding on click behavior.
- User friendly strings to represent employee status.