### PR TITLE
[FP-750] Pathfinding refinement

### DIFF
--- a/game/coffee_vending_machine.gd
+++ b/game/coffee_vending_machine.gd
@@ -1,0 +1,21 @@
+extends RigidBody2D
+
+signal obstacle_added(obstacle_id :int, obstructed_area: Polygon2D)
+signal obstacle_removed(obstacle_id: int)
+
+func _ready() -> void:
+	var collision_shape = $CollisionShape2D
+	var rect_shape = collision_shape.shape.get_rect()
+	var navigation_outline = Polygon2D.new()
+	navigation_outline.polygon = [
+		rect_shape.position,
+		rect_shape.position + Vector2(rect_shape.size.x, 0),
+		rect_shape.position + Vector2(0, rect_shape.size.y),
+		rect_shape.end
+	]
+	navigation_outline.global_position = collision_shape.global_position
+	obstacle_added.emit(get_instance_id(), navigation_outline)
+
+func _notification(what): 
+	if what == NOTIFICATION_PREDELETE: 
+		obstacle_removed.emit(get_instance_id())

--- a/game/coffee_vending_machine.tscn
+++ b/game/coffee_vending_machine.tscn
@@ -1,5 +1,6 @@
-[gd_scene load_steps=4 format=3 uid="uid://bmpybft7fkq38"]
+[gd_scene load_steps=5 format=3 uid="uid://bmpybft7fkq38"]
 
+[ext_resource type="Script" path="res://coffee_vending_machine.gd" id="1_6gf7m"]
 [ext_resource type="Texture2D" uid="uid://bpcey1nf8gteo" path="res://art/coffee_vending_machine.png" id="1_yk382"]
 
 [sub_resource type="SpriteFrames" id="SpriteFrames_fr4xa"]
@@ -20,6 +21,7 @@ size = Vector2(38, 13)
 y_sort_enabled = true
 collision_mask = 0
 gravity_scale = 0.0
+script = ExtResource("1_6gf7m")
 
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
 y_sort_enabled = true

--- a/game/coffee_vending_machine_container.gd
+++ b/game/coffee_vending_machine_container.gd
@@ -1,0 +1,11 @@
+extends Node2D
+
+@export var coffee_vending_machine_scene: PackedScene
+@export var navigation_region: NavigationRegion2D
+
+func create_coffee_vending_machine(desired_position: Vector2) -> void:
+	var coffee_vending_machine = coffee_vending_machine_scene.instantiate()
+	coffee_vending_machine.position 	= desired_position
+	coffee_vending_machine.obstacle_added.connect(navigation_region.obstacle_added)
+	coffee_vending_machine.obstacle_removed.connect(navigation_region.obstacle_removed)
+	add_child(coffee_vending_machine)

--- a/game/damage_numbers.gd
+++ b/game/damage_numbers.gd
@@ -18,7 +18,7 @@ func display_number(value: int, position: Vector2, is_critical: bool = false):
 	number.label_settings.outline_color = "#000"
 	number.label_settings.outline_size = 1
 	
-	call_deferred("add_child", number)
+	get_tree().root.call_deferred("add_child", number)
 	
 	await number.resized
 	number.pivot_offset = Vector2(number.size / 2)

--- a/game/employee.gd
+++ b/game/employee.gd
@@ -58,7 +58,9 @@ func act(current_time: int) -> void:
 					print(str(identity) + ': not reachable')
 					walking_to_work_area = false
 			else:
-				work_area = Vector2(work_area.x + randi_range(-100, 100), work_area.y + randi_range(-100, 100))
+				var angle = randf_range(0, TAU)
+				var distance = randf_range(0, 100)
+				work_area = work_area + Vector2(cos(angle), sin(angle)) * distance
 				print(str(identity) + ': setting work area target')
 				$NavigationAgent2D.target_position = work_area
 				walking_to_work_area = true

--- a/game/employee.gd
+++ b/game/employee.gd
@@ -44,14 +44,15 @@ func act(current_time: int) -> void:
 
 		# Try to get to specified work area.
 		var work_area = $"../../EmployeeWorkArea".global_position
+		print(str(identity) + ': distance to work area ' + str(global_position.distance_to(work_area)))
 		if global_position.distance_to(work_area) > 100:
 			if walking_to_work_area:
 				if !$NavigationAgent2D.is_target_reachable():
-					print('not reachable')
+					print(str(identity) + ': not reachable')
 					walking_to_work_area = false
 			else:
 				work_area = Vector2(work_area.x + randi_range(-100, 100), work_area.y + randi_range(-100, 100))
-				print('setting work area target')
+				print(str(identity) + ': setting work area target')
 				$NavigationAgent2D.target_position = work_area
 				walking_to_work_area = true
 			return

--- a/game/employee.gd
+++ b/game/employee.gd
@@ -37,9 +37,7 @@ func act(current_time: int) -> void:
 		
 		if carrying_package:
 			if navigation_agent.is_navigation_finished():
-				var package = $"../../Player".package_scene.instantiate()
-				package.position = navigation_agent.target_position
-				$"../../PackageContainer".add_child(package)
+				$"../../PackageContainer".create_package(navigation_agent.target_position)
 				carrying_package = false
 			else:
 				return

--- a/game/employee.gd
+++ b/game/employee.gd
@@ -126,7 +126,9 @@ func _on_navigation_agent_2d_velocity_computed(safe_velocity: Vector2) -> void:
 	move_and_slide()
 
 func _process(_delta: float) -> void:
-	if walking_to_work_area || walking_to_commute_tile || carrying_package:
+	var has_walking_intent = walking_to_work_area || walking_to_commute_tile || carrying_package
+	var is_navigating = !navigation_agent.is_navigation_finished()
+	if has_walking_intent && is_navigating:
 		$AnimatedSprite2D.play()
 		set_and_signal_obstacle_state(false)
 	else:

--- a/game/employee_navigation_region.gd
+++ b/game/employee_navigation_region.gd
@@ -1,0 +1,23 @@
+extends NavigationRegion2D
+
+var ready_for_rebake := true
+var obstacle_instances := {}
+	
+func _process(_delta: float) -> void:
+	if ready_for_rebake:
+		ready_for_rebake = false
+		bake_navigation_polygon()
+
+func obstacle_added(obstacle_id: int, obstructed_area: Polygon2D) -> void:
+	print('obstacle added ' + str(obstacle_id))
+	add_child(obstructed_area)
+	obstacle_instances[obstacle_id] = obstructed_area
+	ready_for_rebake = true
+	
+func obstacle_removed(obstacle_id: int) -> void:
+	print('obstacle removed ' + str(obstacle_id))
+	var obstacle = obstacle_instances.get(obstacle_id)
+	if obstacle != null:
+		obstacle_instances.erase(obstacle_id)
+		obstacle.queue_free()
+		ready_for_rebake = true

--- a/game/employee_navigation_region.gd
+++ b/game/employee_navigation_region.gd
@@ -9,13 +9,13 @@ func _process(_delta: float) -> void:
 		bake_navigation_polygon()
 
 func obstacle_added(obstacle_id: int, obstructed_area: Polygon2D) -> void:
-	print('obstacle added ' + str(obstacle_id))
+	#print('obstacle added ' + str(obstacle_id))
 	add_child(obstructed_area)
 	obstacle_instances[obstacle_id] = obstructed_area
 	ready_for_rebake = true
 	
 func obstacle_removed(obstacle_id: int) -> void:
-	print('obstacle removed ' + str(obstacle_id))
+	#print('obstacle removed ' + str(obstacle_id))
 	var obstacle = obstacle_instances.get(obstacle_id)
 	if obstacle != null:
 		obstacle_instances.erase(obstacle_id)

--- a/game/furniture.gd
+++ b/game/furniture.gd
@@ -1,0 +1,22 @@
+extends RigidBody2D
+
+signal obstacle_added(obstacle_id :int, obstructed_area: Polygon2D)
+signal obstacle_removed(obstacle_id: int)
+
+func _ready() -> void:
+	var collision_shape = $CollisionShape2D
+	var rect_shape = collision_shape.shape
+	var navigation_outline = Polygon2D.new()
+	var extents = (rect_shape.size / 2) + Vector2(20, 20)
+	navigation_outline.polygon = [
+		Vector2(-extents.x, -extents.y),
+		Vector2(extents.x, -extents.y),
+		Vector2(extents.x, extents.y),
+		Vector2(-extents.x, extents.y)
+	]
+	navigation_outline.global_position = collision_shape.global_position
+	obstacle_added.emit(get_instance_id(), navigation_outline)
+
+func _notification(what): 
+	if what == NOTIFICATION_PREDELETE: 
+		obstacle_removed.emit(get_instance_id())

--- a/game/furniture.gd
+++ b/game/furniture.gd
@@ -5,14 +5,13 @@ signal obstacle_removed(obstacle_id: int)
 
 func _ready() -> void:
 	var collision_shape = $CollisionShape2D
-	var rect_shape = collision_shape.shape
+	var rect_shape = collision_shape.shape.get_rect()
 	var navigation_outline = Polygon2D.new()
-	var extents = (rect_shape.size / 2) + Vector2(20, 20)
 	navigation_outline.polygon = [
-		Vector2(-extents.x, -extents.y),
-		Vector2(extents.x, -extents.y),
-		Vector2(extents.x, extents.y),
-		Vector2(-extents.x, extents.y)
+		rect_shape.position,
+		rect_shape.position + Vector2(rect_shape.size.x, 0),
+		rect_shape.position + Vector2(0, rect_shape.size.y),
+		rect_shape.end
 	]
 	navigation_outline.global_position = collision_shape.global_position
 	obstacle_added.emit(get_instance_id(), navigation_outline)

--- a/game/furniture.tscn
+++ b/game/furniture.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=5 format=3 uid="uid://cu5shp7i66fhf"]
 
+[ext_resource type="Script" path="res://furniture.gd" id="1_4r8bh"]
 [ext_resource type="Texture2D" uid="uid://dfxrfhliyxfcg" path="res://art/basic_workbench.png" id="1_ths7t"]
-[ext_resource type="PackedScene" uid="uid://cg1dr04okmiv3" path="res://furniture_collision_shape.tscn" id="2_a84ix"]
 
 [sub_resource type="SpriteFrames" id="SpriteFrames_nxxwv"]
 animations = [{
@@ -14,12 +14,13 @@ animations = [{
 "speed": 3.0
 }]
 
-[sub_resource type="RectangleShape2D" id="RectangleShape2D_1xjgm"]
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_dbnej"]
 size = Vector2(51.5, 60)
 
 [node name="Furniture" type="RigidBody2D"]
 collision_mask = 0
 gravity_scale = 0.0
+script = ExtResource("1_4r8bh")
 metadata/_edit_group_ = true
 
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
@@ -27,10 +28,7 @@ scale = Vector2(0.75, 0.75)
 sprite_frames = SubResource("SpriteFrames_nxxwv")
 animation = &"idle"
 
-[node name="FurnitureCollisionShape" parent="." instance=ExtResource("2_a84ix")]
-position = Vector2(0.500095, 7.75)
-shape = SubResource("RectangleShape2D_1xjgm")
-
-[node name="VisibleOnScreenNotifier2D" type="VisibleOnScreenNotifier2D" parent="."]
-
-[connection signal="screen_exited" from="VisibleOnScreenNotifier2D" to="." method="_on_visible_on_screen_notifier_2d_screen_exited"]
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+position = Vector2(0.5, 7.75)
+rotation = 1.5708
+shape = SubResource("RectangleShape2D_dbnej")

--- a/game/furniture_collision_shape.tscn
+++ b/game/furniture_collision_shape.tscn
@@ -1,9 +1,0 @@
-[gd_scene load_steps=2 format=3 uid="uid://cg1dr04okmiv3"]
-
-[sub_resource type="RectangleShape2D" id="RectangleShape2D_2u4yq"]
-size = Vector2(64.0002, 64)
-
-[node name="CollisionShape2D" type="CollisionShape2D"]
-position = Vector2(0.000115395, 1.41307e-05)
-rotation = 1.5708
-shape = SubResource("RectangleShape2D_2u4yq")

--- a/game/furniture_container.gd
+++ b/game/furniture_container.gd
@@ -1,0 +1,11 @@
+extends Node2D
+
+@export var furniture_scene: PackedScene
+@export var navigation_region: NavigationRegion2D
+
+func create_furniture(desired_position: Vector2) -> void:
+	var furniture = furniture_scene.instantiate()
+	furniture.position 	= desired_position
+	furniture.obstacle_added.connect(navigation_region.obstacle_added)
+	furniture.obstacle_removed.connect(navigation_region.obstacle_removed)
+	add_child(furniture)

--- a/game/main.gd
+++ b/game/main.gd
@@ -25,7 +25,9 @@ func game_over() -> void:
 func new_game():
 	net_worth = 1000
 	current_time = 6 * 60
-	drive_points = 100
+	drive_points = 100	
+	$Player.obstacle_added.connect($EmployeeNavigationRegion.obstacle_added)
+	$Player.obstacle_removed.connect($EmployeeNavigationRegion.obstacle_removed)
 	$Player.start($StartPosition.position)
 	$DayTimer.start()
 	$HUD.update_net_worth(net_worth)

--- a/game/main.gd
+++ b/game/main.gd
@@ -10,8 +10,6 @@ var employee_instances = {}
 @export var employee_scene: PackedScene
 @export var employee_carry_scene: PackedScene
 @export var employee_container: Node2D
-@export var coffee_vending_machine_scene: PackedScene
-
 
 func game_over() -> void:
 	$ScoreTimer.stop()
@@ -194,10 +192,7 @@ func _on_player_coffee_vending_machine_placement_requested(position: Vector2) ->
 	if net_worth >= COFFEE_VENDING_MACHINE_COST:
 		net_worth -= COFFEE_VENDING_MACHINE_COST
 		$HUD.update_net_worth(net_worth)
-		var coffee_vending_machine = coffee_vending_machine_scene.instantiate()
-		coffee_vending_machine.position = position
-		coffee_vending_machine.y_sort_enabled = true
-		$CoffeeVendingMachineContainer.add_child(coffee_vending_machine)
+		$CoffeeVendingMachineContainer.create_coffee_vending_machine(position)
 		$Player.in_coffee_zone = true
 
 

--- a/game/main.gd
+++ b/game/main.gd
@@ -136,7 +136,7 @@ func _on_player_widget_action_requested(position: Vector2, actor_position: Vecto
 		$HUD.update_drive_points(drive_points)
 
 	if $WidgetContainer.is_buildable_position(position):
-		place_widget(position)
+		$WidgetContainer.create_widget(position)
 		drive_points -= 5
 		$HUD.update_drive_points(drive_points)
 		
@@ -149,14 +149,7 @@ func _on_employee_widget_action_requested(position: Vector2, actor_position: Vec
 		clicked_widget.build(10)
 
 	if $WidgetContainer.is_buildable_position(position):
-		place_widget(position)
-
-
-func place_widget(spawn_location: Vector2):
-	var widget = widget_scene.instantiate()
-	widget.position = spawn_location
-	$WidgetContainer.add_child(widget)
-
+		$WidgetContainer.create_widget(position)
 
 func _on_hud_action_bar_button_pressed() -> void:
 	$Player.action_selected()

--- a/game/main.gd
+++ b/game/main.gd
@@ -13,7 +13,6 @@ var employee_instances = {}
 @export var employee_carry_scene: PackedScene
 @export var employee_container: Node2D
 @export var widget_scene: PackedScene
-@export var package_scene: PackedScene
 @export var coffee_vending_machine_scene: PackedScene
 
 
@@ -58,7 +57,6 @@ func _on_player_furniture_placement_requested(position: Vector2) -> void:
 		nav_outline.global_position = collision_shape.global_position
 		nav_outline.color = Color(1, 0, 0, 0.5)
 		$NavigationRegion2D.add_child(nav_outline)
-		$NavigationRegion2D.bake_navigation_polygon()
 
 func _on_day_timer_timeout() -> void:
 	current_time += 5
@@ -205,9 +203,7 @@ func _on_player_package_widget_requested(position: Vector2, actor_position: Vect
 		var circle = collision_shape.shape as CircleShape2D
 		var radius = circle.radius
 		if position.distance_to(collision_shape.global_position) <= radius && widget.is_packable():
-			var package = package_scene.instantiate()
-			package.position = widget.position
-			$PackageContainer.add_child(package)
+			$PackageContainer.create_package(widget.position)
 			widget.queue_free()
 
 
@@ -224,3 +220,14 @@ func _on_player_coffee_vending_machine_placement_requested(position: Vector2) ->
 		coffee_vending_machine.y_sort_enabled = true
 		$CoffeeVendingMachineContainer.add_child(coffee_vending_machine)
 		$Player.in_coffee_zone = true
+
+
+func _on_player_carry_action_requested(position: Vector2, actor_position: Vector2) -> void:
+	if $Player.carrying_package && position.distance_to(actor_position) < 100:
+		$PackageContainer.create_package(position)
+		$Player.carrying_package = false
+	else:
+		var package = $PackageContainer.get_package_at_position(position)
+		if package != null && position.distance_to(actor_position) < 100:
+			$Player.carrying_package = true
+			package.queue_free()

--- a/game/main.gd
+++ b/game/main.gd
@@ -7,12 +7,9 @@ var player_tile_position
 var carry_package
 var employee_instances = {}
 
-@export var furniture_scene: PackedScene
-@export var furniture_container: Node2D
 @export var employee_scene: PackedScene
 @export var employee_carry_scene: PackedScene
 @export var employee_container: Node2D
-@export var widget_scene: PackedScene
 @export var coffee_vending_machine_scene: PackedScene
 
 

--- a/game/main.gd
+++ b/game/main.gd
@@ -43,22 +43,7 @@ func _on_player_furniture_placement_requested(position: Vector2) -> void:
 	if net_worth >= FURNITURE_COST:
 		net_worth -= FURNITURE_COST
 		$HUD.update_net_worth(net_worth)
-		var furniture = furniture_scene.instantiate()
-		furniture.position = position
-		furniture_container.add_child(furniture)
-		var collision_shape = furniture.get_node("FurnitureCollisionShape")
-		var rect_shape = collision_shape.shape
-		var nav_outline = Polygon2D.new()
-		var extents = (rect_shape.size / 2) + Vector2(20, 20)
-		nav_outline.polygon = [
-			Vector2(-extents.x, -extents.y),
-			Vector2(extents.x, -extents.y),
-			Vector2(extents.x, extents.y),
-			Vector2(-extents.x, extents.y)
-		]
-		nav_outline.global_position = collision_shape.global_position
-		nav_outline.color = Color(1, 0, 0, 0.5)
-		$NavigationRegion2D.add_child(nav_outline)
+		$FurnitureContainer.create_furniture(position)
 
 func _on_day_timer_timeout() -> void:
 	current_time += 5

--- a/game/main.gd
+++ b/game/main.gd
@@ -86,6 +86,8 @@ func _on_hud_employee_recruited(recruited_employee: Enums.Employees) -> void:
 	employee.money_owed_updated.connect(_on_employee_money_owed_updated)
 	employee.widget_action_requested.connect(_on_employee_widget_action_requested)
 	employee.package_widget_requested.connect(_on_player_package_widget_requested)
+	employee.obstacle_added.connect($EmployeeNavigationRegion.obstacle_added)
+	employee.obstacle_removed.connect($EmployeeNavigationRegion.obstacle_removed)
 	employee_instances[recruited_employee] = employee
 
 

--- a/game/main.tscn
+++ b/game/main.tscn
@@ -222,9 +222,11 @@ stream = ExtResource("5_ppkhf")
 [node name="FurnitureContainer" type="Node2D" parent="."]
 y_sort_enabled = true
 
-[node name="WidgetContainer" type="Node2D" parent="."]
+[node name="WidgetContainer" type="Node2D" parent="." node_paths=PackedStringArray("navigation_region")]
 y_sort_enabled = true
 script = ExtResource("14_0md0v")
+widget_scene = ExtResource("3_xbnie")
+navigation_region = NodePath("../EmployeeNavigationRegion")
 
 [node name="PackageContainer" type="Node2D" parent="." node_paths=PackedStringArray("navigation_region")]
 y_sort_enabled = true

--- a/game/main.tscn
+++ b/game/main.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=41 format=4 uid="uid://g5esyvn2vduv"]
+[gd_scene load_steps=42 format=4 uid="uid://g5esyvn2vduv"]
 
 [ext_resource type="PackedScene" uid="uid://bhcswl07nrnps" path="res://player.tscn" id="1_7mjmw"]
 [ext_resource type="Script" path="res://main.gd" id="1_jxwdf"]
@@ -15,6 +15,7 @@
 [ext_resource type="Script" path="res://mailman.gd" id="8_px6ih"]
 [ext_resource type="Texture2D" uid="uid://ycjfn1nfmonq" path="res://art/widget_create1.png" id="9_71qoh"]
 [ext_resource type="Texture2D" uid="uid://c3ujp3okifr51" path="res://art/mailman.png" id="9_daadb"]
+[ext_resource type="Script" path="res://employee_navigation_region.gd" id="9_gd5qs"]
 [ext_resource type="Texture2D" uid="uid://d1ii3a7joyw4p" path="res://art/widget_build1.png" id="9_mokby"]
 [ext_resource type="Texture2D" uid="uid://7qi17hucq46s" path="res://art/widget_build2.png" id="10_5uig0"]
 [ext_resource type="Texture2D" uid="uid://ke0rfj74784h" path="res://art/widget_create2.png" id="10_c7lq0"]
@@ -183,15 +184,15 @@ employee_scene = ExtResource("3_u4axo")
 employee_carry_scene = ExtResource("4_ah1jg")
 employee_container = NodePath("EmployeeContainer")
 widget_scene = ExtResource("3_xbnie")
-package_scene = ExtResource("7_g140p")
 coffee_vending_machine_scene = ExtResource("6_atv1o")
 
 [node name="TileMapLayer" parent="." instance=ExtResource("5_1cbru")]
 
-[node name="NavigationRegion2D" type="NavigationRegion2D" parent="."]
+[node name="EmployeeNavigationRegion" type="NavigationRegion2D" parent="."]
 navigation_polygon = SubResource("NavigationPolygon_bf4m7")
+script = ExtResource("9_gd5qs")
 
-[node name="WallObstacle" type="Polygon2D" parent="NavigationRegion2D"]
+[node name="WallObstacle" type="Polygon2D" parent="EmployeeNavigationRegion"]
 polygon = PackedVector2Array(544, 576, -32, 288, 480, 24, 1056, 320, 928, 392, 496, 168, 224, 296, 648, 520)
 
 [node name="Camera2D" type="Camera2D" parent="." node_paths=PackedStringArray("player")]
@@ -228,9 +229,11 @@ y_sort_enabled = true
 y_sort_enabled = true
 script = ExtResource("14_0md0v")
 
-[node name="PackageContainer" type="Node2D" parent="."]
+[node name="PackageContainer" type="Node2D" parent="." node_paths=PackedStringArray("navigation_region")]
 y_sort_enabled = true
 script = ExtResource("12_mohxw")
+package_scene = ExtResource("7_g140p")
+navigation_region = NodePath("../EmployeeNavigationRegion")
 
 [node name="EmployeeContainer" type="Node2D" parent="."]
 y_sort_enabled = true
@@ -267,6 +270,7 @@ position = Vector2(1128, 816)
 [node name="EmployeeShippingDrop" type="Marker2D" parent="."]
 position = Vector2(928, 432)
 
+[connection signal="carry_action_requested" from="Player" to="." method="_on_player_carry_action_requested"]
 [connection signal="coffee_vending_machine_placement_requested" from="Player" to="." method="_on_player_coffee_vending_machine_placement_requested"]
 [connection signal="furniture_placement_requested" from="Player" to="." method="_on_player_furniture_placement_requested"]
 [connection signal="moved" from="Player" to="." method="_on_player_moved"]

--- a/game/main.tscn
+++ b/game/main.tscn
@@ -176,15 +176,12 @@ animations = [{
 "speed": 5.0
 }]
 
-[node name="Main" type="Node2D" node_paths=PackedStringArray("furniture_container", "employee_container")]
+[node name="Main" type="Node2D" node_paths=PackedStringArray("employee_container")]
 y_sort_enabled = true
 script = ExtResource("1_jxwdf")
-furniture_scene = ExtResource("4_mg1l2")
-furniture_container = NodePath("FurnitureContainer")
 employee_scene = ExtResource("3_u4axo")
 employee_carry_scene = ExtResource("4_ah1jg")
 employee_container = NodePath("EmployeeContainer")
-widget_scene = ExtResource("3_xbnie")
 coffee_vending_machine_scene = ExtResource("6_atv1o")
 
 [node name="TileMapLayer" parent="." instance=ExtResource("5_1cbru")]

--- a/game/main.tscn
+++ b/game/main.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=43 format=4 uid="uid://g5esyvn2vduv"]
+[gd_scene load_steps=44 format=4 uid="uid://g5esyvn2vduv"]
 
 [ext_resource type="PackedScene" uid="uid://bhcswl07nrnps" path="res://player.tscn" id="1_7mjmw"]
 [ext_resource type="Script" path="res://main.gd" id="1_jxwdf"]
@@ -27,6 +27,7 @@
 [ext_resource type="Texture2D" uid="uid://hscmf3ecjywg" path="res://art/basic_workbench_invalid1.png" id="14_8bxa5"]
 [ext_resource type="Texture2D" uid="uid://cn1f8b36um0nh" path="res://art/basic_workbench_create2.png" id="15_2uysg"]
 [ext_resource type="Texture2D" uid="uid://dbarb441y4ck" path="res://art/basic_workbench_invalid2.png" id="15_c5p6a"]
+[ext_resource type="Script" path="res://coffee_vending_machine_container.gd" id="16_d0q70"]
 [ext_resource type="Texture2D" uid="uid://dyphviqmre33k" path="res://art/hand1.png" id="19_hgwrt"]
 [ext_resource type="Texture2D" uid="uid://p4dst3dueqpl" path="res://art/hand2.png" id="20_81fmh"]
 [ext_resource type="Texture2D" uid="uid://clqa62kr0vmri" path="res://art/carry_package.png" id="21_2dno5"]
@@ -182,7 +183,6 @@ script = ExtResource("1_jxwdf")
 employee_scene = ExtResource("3_u4axo")
 employee_carry_scene = ExtResource("4_ah1jg")
 employee_container = NodePath("EmployeeContainer")
-coffee_vending_machine_scene = ExtResource("6_atv1o")
 
 [node name="TileMapLayer" parent="." instance=ExtResource("5_1cbru")]
 navigation_enabled = false
@@ -239,8 +239,11 @@ navigation_region = NodePath("../EmployeeNavigationRegion")
 [node name="EmployeeContainer" type="Node2D" parent="."]
 y_sort_enabled = true
 
-[node name="CoffeeVendingMachineContainer" type="Node2D" parent="."]
+[node name="CoffeeVendingMachineContainer" type="Node2D" parent="." node_paths=PackedStringArray("navigation_region")]
 y_sort_enabled = true
+script = ExtResource("16_d0q70")
+coffee_vending_machine_scene = ExtResource("6_atv1o")
+navigation_region = NodePath("../EmployeeNavigationRegion")
 
 [node name="DayTimer" type="Timer" parent="."]
 wait_time = 2.5

--- a/game/main.tscn
+++ b/game/main.tscn
@@ -199,11 +199,8 @@ polygon = PackedVector2Array(544, 576, -32, 288, 480, 24, 1056, 320, 928, 392, 4
 script = ExtResource("6_ygvik")
 player = NodePath("../Player")
 
-[node name="Player" parent="." node_paths=PackedStringArray("widget_container", "package_container") instance=ExtResource("1_7mjmw")]
+[node name="Player" parent="." instance=ExtResource("1_7mjmw")]
 y_sort_enabled = true
-widget_container = NodePath("../WidgetContainer")
-package_scene = ExtResource("7_g140p")
-package_container = NodePath("../PackageContainer")
 
 [node name="StartPosition" type="Marker2D" parent="."]
 position = Vector2(1056, 776)

--- a/game/main.tscn
+++ b/game/main.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=42 format=4 uid="uid://g5esyvn2vduv"]
+[gd_scene load_steps=43 format=4 uid="uid://g5esyvn2vduv"]
 
 [ext_resource type="PackedScene" uid="uid://bhcswl07nrnps" path="res://player.tscn" id="1_7mjmw"]
 [ext_resource type="Script" path="res://main.gd" id="1_jxwdf"]
@@ -21,6 +21,7 @@
 [ext_resource type="Texture2D" uid="uid://ke0rfj74784h" path="res://art/widget_create2.png" id="10_c7lq0"]
 [ext_resource type="Script" path="res://cursor_indicator.gd" id="11_j04ey"]
 [ext_resource type="Script" path="res://package_container.gd" id="12_mohxw"]
+[ext_resource type="Script" path="res://furniture_container.gd" id="13_fed4l"]
 [ext_resource type="Script" path="res://widget_container.gd" id="14_0md0v"]
 [ext_resource type="Texture2D" uid="uid://d2l0gmod4mml6" path="res://art/basic_workbench_create1.png" id="14_8b740"]
 [ext_resource type="Texture2D" uid="uid://hscmf3ecjywg" path="res://art/basic_workbench_invalid1.png" id="14_8bxa5"]
@@ -219,8 +220,11 @@ stream = SubResource("AudioStreamOggVorbis_5efd5")
 [node name="DeathSound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("5_ppkhf")
 
-[node name="FurnitureContainer" type="Node2D" parent="."]
+[node name="FurnitureContainer" type="Node2D" parent="." node_paths=PackedStringArray("navigation_region")]
 y_sort_enabled = true
+script = ExtResource("13_fed4l")
+furniture_scene = ExtResource("4_mg1l2")
+navigation_region = NodePath("../EmployeeNavigationRegion")
 
 [node name="WidgetContainer" type="Node2D" parent="." node_paths=PackedStringArray("navigation_region")]
 y_sort_enabled = true

--- a/game/main.tscn
+++ b/game/main.tscn
@@ -188,6 +188,7 @@ widget_scene = ExtResource("3_xbnie")
 coffee_vending_machine_scene = ExtResource("6_atv1o")
 
 [node name="TileMapLayer" parent="." instance=ExtResource("5_1cbru")]
+navigation_enabled = false
 
 [node name="EmployeeNavigationRegion" type="NavigationRegion2D" parent="."]
 navigation_polygon = SubResource("NavigationPolygon_bf4m7")

--- a/game/package.gd
+++ b/game/package.gd
@@ -1,12 +1,12 @@
 extends RigidBody2D
 
-var navigation_outline: Polygon2D
+signal obstacle_added(obstacle_id :int, obstructed_area: Polygon2D)
+signal obstacle_removed(obstacle_id: int)
 
 func _ready() -> void:
-	var navigation_region = $"../../NavigationRegion2D"
 	var collision_shape = $CollisionShape2D
 	var rect_shape = collision_shape.shape
-	navigation_outline = Polygon2D.new()
+	var navigation_outline = Polygon2D.new()
 	var extents = (rect_shape.size / 2) + Vector2(20, 20)
 	navigation_outline.polygon = [
 		Vector2(-extents.x, -extents.y),
@@ -15,9 +15,8 @@ func _ready() -> void:
 		Vector2(-extents.x, extents.y)
 	]
 	navigation_outline.global_position = collision_shape.global_position
-	navigation_region.add_child(navigation_outline)
-	navigation_region.bake_navigation_polygon()
+	obstacle_added.emit(get_instance_id(), navigation_outline)
 
 func _notification(what): 
 	if what == NOTIFICATION_PREDELETE: 
-		navigation_outline.queue_free()
+		obstacle_removed.emit(get_instance_id())

--- a/game/package.gd
+++ b/game/package.gd
@@ -5,14 +5,13 @@ signal obstacle_removed(obstacle_id: int)
 
 func _ready() -> void:
 	var collision_shape = $CollisionShape2D
-	var rect_shape = collision_shape.shape
+	var rect_shape = collision_shape.shape.get_rect()
 	var navigation_outline = Polygon2D.new()
-	var extents = (rect_shape.size / 2) + Vector2(20, 20)
 	navigation_outline.polygon = [
-		Vector2(-extents.x, -extents.y),
-		Vector2(extents.x, -extents.y),
-		Vector2(extents.x, extents.y),
-		Vector2(-extents.x, extents.y)
+		rect_shape.position,
+		rect_shape.position + Vector2(rect_shape.size.x, 0),
+		rect_shape.position + Vector2(0, rect_shape.size.y),
+		rect_shape.end
 	]
 	navigation_outline.global_position = collision_shape.global_position
 	obstacle_added.emit(get_instance_id(), navigation_outline)

--- a/game/package_container.gd
+++ b/game/package_container.gd
@@ -1,5 +1,7 @@
 extends Node2D
 
+@export var package_scene: PackedScene
+@export var navigation_region: NavigationRegion2D
 
 func get_package_at_position(selected_position: Vector2) -> Node2D:
 	for package in get_children():
@@ -7,3 +9,10 @@ func get_package_at_position(selected_position: Vector2) -> Node2D:
 			return package
 			
 	return null
+
+func create_package(desired_position: Vector2) -> void:
+	var package = package_scene.instantiate()
+	package.position = desired_position
+	package.obstacle_added.connect(navigation_region.obstacle_added)
+	package.obstacle_removed.connect(navigation_region.obstacle_removed)
+	add_child(package)

--- a/game/player.gd
+++ b/game/player.gd
@@ -5,6 +5,7 @@ signal package_widget_requested(position: Vector2, actor_position: Vector2)
 signal widget_action_requested(position: Vector2)
 signal moved(position: Vector2)
 signal coffee_vending_machine_placement_requested(position: Vector2)
+signal carry_action_requested(position: Vector2, actor_position: Vector2)
 
 @export var speed = 375.0
 @export var widget_container: Node2D
@@ -71,17 +72,7 @@ func _unhandled_input(event: InputEvent) -> void:
 		if GameState.selected_action == Enums.Actions.PACK:
 			package_widget_requested.emit(get_global_mouse_position(), position)
 		if GameState.selected_action == Enums.Actions.CARRY:
-			var mouse_position = get_global_mouse_position()
-			if carrying_package && mouse_position.distance_to(position) < 100:
-				var package = package_scene.instantiate()
-				package.position = mouse_position
-				package_container.add_child(package)
-				carrying_package = false
-			else:
-				var package = package_container.get_package_at_position(mouse_position)
-				if package != null && mouse_position.distance_to(position) < 100:
-					carrying_package = true
-					package.queue_free()
+			carry_action_requested.emit(get_global_mouse_position(), position)
 		if GameState.selected_action == Enums.Actions.COFFEE_VENDING_MACHINE:
 			coffee_vending_machine_placement_requested.emit(get_global_mouse_position())
 

--- a/game/player.gd
+++ b/game/player.gd
@@ -94,12 +94,11 @@ func set_and_signal_obstacle_state(desired_obstacle_state: bool) -> void:
 		var collision_shape = $CollisionShape2D
 		var rect_shape = collision_shape.shape.get_rect()
 		var navigation_outline = Polygon2D.new()
-		var extents = (rect_shape.size / 2) + Vector2(20, 20)
 		navigation_outline.polygon = [
-			Vector2(-extents.x, -extents.y),
-			Vector2(extents.x, -extents.y),
-			Vector2(extents.x, extents.y),
-			Vector2(-extents.x, extents.y)
+			rect_shape.position,
+			rect_shape.position + Vector2(rect_shape.size.x, 0),
+			rect_shape.position + Vector2(0, rect_shape.size.y),
+			rect_shape.end
 		]
 		navigation_outline.global_position = collision_shape.global_position
 		obstacle_added.emit(get_instance_id(), navigation_outline)

--- a/game/player.gd
+++ b/game/player.gd
@@ -6,16 +6,17 @@ signal widget_action_requested(position: Vector2)
 signal moved(position: Vector2)
 signal coffee_vending_machine_placement_requested(position: Vector2)
 signal carry_action_requested(position: Vector2, actor_position: Vector2)
+signal obstacle_added(obstacle_id :int, obstructed_area: Polygon2D)
+signal obstacle_removed(obstacle_id: int)
 
 @export var speed = 375.0
 
-var screen_size
 var prevent_player_movement = false
 var carrying_package = false
 var in_coffee_zone = false
+var is_navigation_obstacle := true
 
 func _ready() -> void:
-	screen_size = get_viewport_rect().size
 	hide()
 	$AnimatedSprite2D.animation = "walk"
 
@@ -25,6 +26,7 @@ func _process(delta: float) -> void:
 		
 	if prevent_player_movement:
 		$AnimatedSprite2D.stop()
+		set_and_signal_obstacle_state(true)
 		return
 	
 	var input_dir = Input.get_vector("move_left", "move_right", "move_up", "move_down")
@@ -33,14 +35,17 @@ func _process(delta: float) -> void:
 	if velocity.length() > 0:
 		velocity = velocity.normalized() * speed
 		$AnimatedSprite2D.play()
+		set_and_signal_obstacle_state(false)
 		$AnimatedSprite2D.speed_scale = 1.0
 		moved.emit(global_position)
 	elif in_coffee_zone:
 		$AnimatedSprite2D.play()
+		set_and_signal_obstacle_state(false)
 		$AnimatedSprite2D.speed_scale = 0.125
 		$AnimatedSprite2D.animation = "drink"
 	else:
 		$AnimatedSprite2D.stop()
+		set_and_signal_obstacle_state(true)
 
 	move_and_collide(velocity * delta)
 	
@@ -75,3 +80,26 @@ func _unhandled_input(event: InputEvent) -> void:
 
 func action_selected() -> void:
 	$RangeMarker.queue_redraw()
+
+func set_and_signal_obstacle_state(desired_obstacle_state: bool) -> void:
+	if is_navigation_obstacle == desired_obstacle_state:
+		return
+		
+	if is_navigation_obstacle && !desired_obstacle_state:
+		is_navigation_obstacle = false
+		obstacle_removed.emit(get_instance_id())
+		
+	if !is_navigation_obstacle && desired_obstacle_state:
+		is_navigation_obstacle = true
+		var collision_shape = $CollisionShape2D
+		var rect_shape = collision_shape.shape.get_rect()
+		var navigation_outline = Polygon2D.new()
+		var extents = (rect_shape.size / 2) + Vector2(20, 20)
+		navigation_outline.polygon = [
+			Vector2(-extents.x, -extents.y),
+			Vector2(extents.x, -extents.y),
+			Vector2(extents.x, extents.y),
+			Vector2(-extents.x, extents.y)
+		]
+		navigation_outline.global_position = collision_shape.global_position
+		obstacle_added.emit(get_instance_id(), navigation_outline)

--- a/game/player.gd
+++ b/game/player.gd
@@ -8,9 +8,6 @@ signal coffee_vending_machine_placement_requested(position: Vector2)
 signal carry_action_requested(position: Vector2, actor_position: Vector2)
 
 @export var speed = 375.0
-@export var widget_container: Node2D
-@export var package_scene: PackedScene
-@export var package_container: Node2D
 
 var screen_size
 var prevent_player_movement = false

--- a/game/widget.gd
+++ b/game/widget.gd
@@ -11,12 +11,11 @@ func _ready() -> void:
 	var collision_shape = $CollisionShape2D
 	var rect_shape = collision_shape.shape.get_rect()
 	var navigation_outline = Polygon2D.new()
-	var extents = (rect_shape.size / 2) + Vector2(20, 20)
 	navigation_outline.polygon = [
-		Vector2(-extents.x, -extents.y),
-		Vector2(extents.x, -extents.y),
-		Vector2(extents.x, extents.y),
-		Vector2(-extents.x, extents.y)
+		rect_shape.position,
+		rect_shape.position + Vector2(rect_shape.size.x, 0),
+		rect_shape.position + Vector2(0, rect_shape.size.y),
+		rect_shape.end
 	]
 	navigation_outline.global_position = collision_shape.global_position
 	obstacle_added.emit(get_instance_id(), navigation_outline)

--- a/game/widget.gd
+++ b/game/widget.gd
@@ -1,10 +1,12 @@
 extends RigidBody2D
 
+signal obstacle_added(obstacle_id :int, obstructed_area: Polygon2D)
+signal obstacle_removed(obstacle_id: int)
+
 var progress
 
 func _ready() -> void:
-	var widget_types = $AnimatedSprite2D.sprite_frames.get_animation_names()
-	$AnimatedSprite2D.play(widget_types[randi() % widget_types.size()])
+	$AnimatedSprite2D.play()
 	progress = 0
 	
 func build(additional_progress: int):

--- a/game/widget.gd
+++ b/game/widget.gd
@@ -3,11 +3,23 @@ extends RigidBody2D
 signal obstacle_added(obstacle_id :int, obstructed_area: Polygon2D)
 signal obstacle_removed(obstacle_id: int)
 
-var progress
+var progress := 0
 
 func _ready() -> void:
 	$AnimatedSprite2D.play()
-	progress = 0
+	
+	var collision_shape = $CollisionShape2D
+	var rect_shape = collision_shape.shape.get_rect()
+	var navigation_outline = Polygon2D.new()
+	var extents = (rect_shape.size / 2) + Vector2(20, 20)
+	navigation_outline.polygon = [
+		Vector2(-extents.x, -extents.y),
+		Vector2(extents.x, -extents.y),
+		Vector2(extents.x, extents.y),
+		Vector2(-extents.x, extents.y)
+	]
+	navigation_outline.global_position = collision_shape.global_position
+	obstacle_added.emit(get_instance_id(), navigation_outline)
 	
 func build(additional_progress: int):
 	DamageNumbers.display_number(additional_progress, $NumberSpawn.global_position, additional_progress > 10)
@@ -18,3 +30,7 @@ func build(additional_progress: int):
 
 func is_packable() -> bool:
 	return progress == 100
+	
+func _notification(what): 
+	if what == NOTIFICATION_PREDELETE: 
+		obstacle_removed.emit(get_instance_id())

--- a/game/widget.tscn
+++ b/game/widget.tscn
@@ -21,7 +21,7 @@ animations = [{
 [sub_resource type="CircleShape2D" id="CircleShape2D_6hbh8"]
 radius = 25.02
 
-[node name="Mob" type="RigidBody2D"]
+[node name="Widget" type="RigidBody2D"]
 collision_mask = 0
 gravity_scale = 0.0
 script = ExtResource("1_fy1tb")

--- a/game/widget_container.gd
+++ b/game/widget_container.gd
@@ -1,5 +1,7 @@
 extends Node2D
 
+@export var widget_scene: PackedScene
+@export var navigation_region: NavigationRegion2D
 
 func get_widget_at_position(selected_position: Vector2) -> Node2D:
 	for widget in get_children():
@@ -26,3 +28,10 @@ func is_buildable_position(selected_position: Vector2) -> bool:
 			clicked_ineligible_placement = true
 			
 	return !clicked_ineligible_placement
+
+func create_widget(desired_position: Vector2) -> void:
+	var widget = widget_scene.instantiate()
+	widget.position = desired_position
+	widget.obstacle_added.connect(navigation_region.obstacle_added)
+	widget.obstacle_removed.connect(navigation_region.obstacle_removed)
+	add_child(widget)


### PR DESCRIPTION
Add remaining static objects (widgets and coffee vending machines) as obstacles in pathfinding.

Employees and the players will now also become obstacles when they aren't moving.

<img width="923" alt="image" src="https://github.com/user-attachments/assets/6feaeef0-5122-4a06-ade3-5a53a087dabe" />


-----

Introduces a new pattern where objects in the world can emit `obstacle_added` and `obstacle_removed` signals.

The navigation region listens to these events, maintains a list of `Polygon2D` children, and rebakes the navigation mesh as needed. It adds some logic to avoid multiple rebakes at the same time which was a flaw in my previous implementation.

-----

Fixes a bug / quirky behavior where employees would still be animated as walking even after completing navigation to the shipping and receiving area while carrying a package.