### PR TITLE
[FP-713] Quest system MVP

### DIFF
--- a/game/damage_numbers.gd
+++ b/game/damage_numbers.gd
@@ -37,3 +37,45 @@ func display_number(value: int, position: Vector2, is_critical: bool = false):
 	
 	await tween.finished
 	number.queue_free()
+	
+	
+func money_number(value: int):
+	if value == 0:
+		return
+	
+	var number = Label.new()
+	number.position = Vector2(554, 56)
+	var prefix = "-$" if value < 0 else "$"
+	number.text = prefix + str(abs(value))
+	print(number.text)
+	number.z_index = 5
+	number.label_settings = LabelSettings.new()
+	
+	var color = "#0F0"
+	if value < 0:
+		color = "#F00"
+		
+	number.label_settings.font_color = color
+	number.label_settings.font_size = 45
+	number.label_settings.outline_color = "#000"
+	number.label_settings.outline_size = 1
+	
+	get_tree().root.get_node("Main").get_node("HUD").call_deferred("add_child", number)
+	
+	await number.resized
+	number.pivot_offset = Vector2(number.size / 2)
+	
+	var tween = get_tree().create_tween()
+	tween.set_parallel(true)
+	tween.tween_property(
+		number, "scale", Vector2(2, 2), .75
+	).set_ease(Tween.EASE_OUT)
+	tween.tween_property(
+		number, "position:y", number.position.y + 56, 0.25
+	).set_ease(Tween.EASE_OUT).set_delay(.75)
+	tween.tween_property(
+		number, "scale", Vector2.ZERO, 0.25
+	).set_ease(Tween.EASE_IN).set_delay(.75)
+	
+	await tween.finished
+	number.queue_free()

--- a/game/hud.gd
+++ b/game/hud.gd
@@ -50,6 +50,7 @@ func update_time(time):
 	if !$AccelerateTimeButton.visible:
 		$AccelerateTimeButton.visible = true
 		$TopBarBackground.visible = true
+		$Quest.visible = true
 	
 	var meridiem_suffix = "AM" if time < 12 * 60 else "PM"
 	var hour = time / 60 if time < 12 * 60 else (time / 60 - 12)
@@ -123,6 +124,7 @@ func _ready() -> void:
 	$DriveProgressBar.visible = false
 	$TopBarBackground.visible = false
 	visible = true
+	$Quest.visible = false
 
 func update_drive_points(drive_points) -> void:
 	$DriveProgressBar.visible = true

--- a/game/hud.gd
+++ b/game/hud.gd
@@ -178,3 +178,6 @@ func _on_fire_carry_button_pressed() -> void:
 	$HRPanel/TabContainer/Recruiting/RecruitCarry.visible = true
 	$HRPanel/TabContainer/Employees/EmployeeCarry.visible = false
 	employee_fired.emit(Enums.Employees.CARRY)
+
+func update_quest_progress(current_quest_progress: float) -> void:
+	$Quest.update_quest_progress(current_quest_progress)

--- a/game/hud.tscn
+++ b/game/hud.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=40 format=3 uid="uid://bw6td1ka2uv5c"]
+[gd_scene load_steps=41 format=3 uid="uid://bw6td1ka2uv5c"]
 
 [ext_resource type="Script" path="res://hud.gd" id="1_0jbru"]
 [ext_resource type="FontFile" uid="uid://cw8737f1dq6n3" path="res://fonts/Xolonium-Regular.ttf" id="1_3xhbu"]
@@ -18,6 +18,7 @@
 [ext_resource type="Texture2D" uid="uid://bxj1a8eg23fpx" path="res://art/action_bar_six1.png" id="14_3ea8n"]
 [ext_resource type="Texture2D" uid="uid://d4b1ksfdmwn1j" path="res://art/action_bar_six2.png" id="15_2srnn"]
 [ext_resource type="Texture2D" uid="uid://bhndpva7hvglu" path="res://art/carry_moore1.png" id="18_brpx8"]
+[ext_resource type="Texture2D" uid="uid://dqlvc1tmxi238" path="res://art/widget1.png" id="19_6gm1h"]
 
 [sub_resource type="Shortcut" id="Shortcut_wpxgg"]
 
@@ -455,6 +456,58 @@ offset_bottom = 36.0
 grow_horizontal = 0
 focus_mode = 0
 text = "X"
+
+[node name="Quest" type="Control" parent="."]
+layout_mode = 3
+anchors_preset = 1
+anchor_left = 1.0
+anchor_right = 1.0
+offset_left = -256.0
+offset_top = 42.0
+offset_bottom = 98.0
+grow_horizontal = 0
+size_flags_horizontal = 8
+size_flags_vertical = 8
+metadata/_edit_use_anchors_ = true
+
+[node name="TopBarBackground" type="ColorRect" parent="Quest"]
+offset_right = 256.0
+offset_bottom = 56.0
+color = Color(0.392157, 0.584314, 0.929412, 0.733333)
+
+[node name="TextureRect" type="TextureRect" parent="Quest"]
+layout_mode = 0
+offset_left = 5.0
+offset_top = 6.0
+offset_right = 51.0
+offset_bottom = 52.0
+texture = ExtResource("19_6gm1h")
+expand_mode = 5
+stretch_mode = 6
+
+[node name="Label" type="Label" parent="Quest"]
+layout_mode = 0
+offset_left = 56.0
+offset_right = 200.0
+offset_bottom = 28.0
+theme_override_fonts/font = ExtResource("1_3xhbu")
+theme_override_font_sizes/font_size = 11
+text = "Build your first widget"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="ProgressBar" type="ProgressBar" parent="Quest"]
+layout_mode = 0
+offset_left = 56.0
+offset_top = 28.0
+offset_right = 200.0
+offset_bottom = 56.0
+
+[node name="CheckButton" type="CheckButton" parent="Quest"]
+layout_mode = 0
+offset_left = 207.0
+offset_right = 251.0
+offset_bottom = 56.0
 
 [connection signal="action_bar_button_pressed" from="." to="HRPanel" method="_on_hud_action_bar_button_pressed"]
 [connection signal="pressed" from="StartButton" to="." method="_on_start_button_pressed"]

--- a/game/hud.tscn
+++ b/game/hud.tscn
@@ -472,12 +472,17 @@ size_flags_vertical = 8
 script = ExtResource("19_unre7")
 metadata/_edit_use_anchors_ = true
 
-[node name="QuestSmallBG" type="ColorRect" parent="Quest"]
+[node name="Header" type="Control" parent="Quest"]
+anchors_preset = 0
+offset_right = 40.0
+offset_bottom = 40.0
+
+[node name="QuestSmallBG" type="ColorRect" parent="Quest/Header"]
 offset_right = 256.0
 offset_bottom = 56.0
 color = Color(0.392157, 0.584314, 0.929412, 0.733333)
 
-[node name="TextureRect" type="TextureRect" parent="Quest"]
+[node name="TextureRect" type="TextureRect" parent="Quest/Header"]
 layout_mode = 0
 offset_left = 5.0
 offset_top = 6.0
@@ -487,7 +492,7 @@ texture = ExtResource("19_6gm1h")
 expand_mode = 5
 stretch_mode = 6
 
-[node name="Label" type="Label" parent="Quest"]
+[node name="Label" type="Label" parent="Quest/Header"]
 layout_mode = 0
 offset_left = 56.0
 offset_right = 200.0
@@ -498,18 +503,22 @@ text = "Build a Widget"
 horizontal_alignment = 1
 vertical_alignment = 1
 
-[node name="ProgressBar" type="ProgressBar" parent="Quest"]
+[node name="ProgressBar" type="ProgressBar" parent="Quest/Header"]
 layout_mode = 0
 offset_left = 56.0
 offset_top = 28.0
 offset_right = 200.0
 offset_bottom = 56.0
 
-[node name="CheckButton" type="CheckButton" parent="Quest"]
+[node name="CheckButton" type="CheckButton" parent="Quest/Header"]
 layout_mode = 0
 offset_left = 207.0
 offset_right = 251.0
 offset_bottom = 56.0
+
+[node name="WiggleTimer" type="Timer" parent="Quest/Header"]
+wait_time = 10.0
+autostart = true
 
 [node name="Collapsible" type="Control" parent="Quest"]
 visible = false
@@ -558,4 +567,5 @@ autowrap_mode = 3
 [connection signal="visibility_changed" from="CommutePanel" to="." method="_on_commute_panel_visibility_changed"]
 [connection signal="pressed" from="CommutePanel/RestButton" to="." method="_on_rest_button_pressed"]
 [connection signal="pressed" from="CommutePanel/CloseCommutePanelButton" to="." method="_on_close_commute_panel_button_pressed"]
-[connection signal="toggled" from="Quest/CheckButton" to="Quest" method="_on_check_button_toggled"]
+[connection signal="toggled" from="Quest/Header/CheckButton" to="Quest" method="_on_check_button_toggled"]
+[connection signal="timeout" from="Quest/Header/WiggleTimer" to="Quest" method="_on_wiggle_timer_timeout"]

--- a/game/hud.tscn
+++ b/game/hud.tscn
@@ -478,6 +478,7 @@ offset_right = 40.0
 offset_bottom = 40.0
 
 [node name="QuestSmallBG" type="ColorRect" parent="Quest/Header"]
+layout_mode = 0
 offset_right = 256.0
 offset_bottom = 56.0
 color = Color(0.392157, 0.584314, 0.929412, 0.733333)
@@ -528,6 +529,7 @@ offset_right = 256.0
 offset_bottom = 547.0
 
 [node name="QuestBigBG" type="ColorRect" parent="Quest/Collapsible"]
+layout_mode = 0
 offset_right = 256.0
 offset_bottom = 491.0
 color = Color(0.392157, 0.584314, 0.929412, 0.733333)

--- a/game/hud.tscn
+++ b/game/hud.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=41 format=3 uid="uid://bw6td1ka2uv5c"]
+[gd_scene load_steps=42 format=3 uid="uid://bw6td1ka2uv5c"]
 
 [ext_resource type="Script" path="res://hud.gd" id="1_0jbru"]
 [ext_resource type="FontFile" uid="uid://cw8737f1dq6n3" path="res://fonts/Xolonium-Regular.ttf" id="1_3xhbu"]
@@ -19,6 +19,7 @@
 [ext_resource type="Texture2D" uid="uid://d4b1ksfdmwn1j" path="res://art/action_bar_six2.png" id="15_2srnn"]
 [ext_resource type="Texture2D" uid="uid://bhndpva7hvglu" path="res://art/carry_moore1.png" id="18_brpx8"]
 [ext_resource type="Texture2D" uid="uid://dqlvc1tmxi238" path="res://art/widget1.png" id="19_6gm1h"]
+[ext_resource type="Script" path="res://quest.gd" id="19_unre7"]
 
 [sub_resource type="Shortcut" id="Shortcut_wpxgg"]
 
@@ -468,9 +469,10 @@ offset_bottom = 98.0
 grow_horizontal = 0
 size_flags_horizontal = 8
 size_flags_vertical = 8
+script = ExtResource("19_unre7")
 metadata/_edit_use_anchors_ = true
 
-[node name="TopBarBackground" type="ColorRect" parent="Quest"]
+[node name="QuestSmallBG" type="ColorRect" parent="Quest"]
 offset_right = 256.0
 offset_bottom = 56.0
 color = Color(0.392157, 0.584314, 0.929412, 0.733333)
@@ -491,8 +493,8 @@ offset_left = 56.0
 offset_right = 200.0
 offset_bottom = 28.0
 theme_override_fonts/font = ExtResource("1_3xhbu")
-theme_override_font_sizes/font_size = 11
-text = "Build your first widget"
+theme_override_font_sizes/font_size = 14
+text = "Build a Widget"
 horizontal_alignment = 1
 vertical_alignment = 1
 
@@ -508,6 +510,33 @@ layout_mode = 0
 offset_left = 207.0
 offset_right = 251.0
 offset_bottom = 56.0
+
+[node name="Collapsible" type="Control" parent="Quest"]
+visible = false
+anchors_preset = 0
+offset_top = 56.0
+offset_right = 256.0
+offset_bottom = 547.0
+
+[node name="QuestBigBG" type="ColorRect" parent="Quest/Collapsible"]
+offset_right = 256.0
+offset_bottom = 491.0
+color = Color(0.392157, 0.584314, 0.929412, 0.733333)
+
+[node name="Label" type="Label" parent="Quest/Collapsible"]
+layout_mode = 0
+offset_left = 8.0
+offset_top = 22.0
+offset_right = 248.0
+offset_bottom = 262.0
+text = "* Create a widget
+* Build it to 100%
+* Package the widget
+* Carry it to the shiping area
+
+Reward:
+$100"
+autowrap_mode = 3
 
 [connection signal="action_bar_button_pressed" from="." to="HRPanel" method="_on_hud_action_bar_button_pressed"]
 [connection signal="pressed" from="StartButton" to="." method="_on_start_button_pressed"]
@@ -529,3 +558,4 @@ offset_bottom = 56.0
 [connection signal="visibility_changed" from="CommutePanel" to="." method="_on_commute_panel_visibility_changed"]
 [connection signal="pressed" from="CommutePanel/RestButton" to="." method="_on_rest_button_pressed"]
 [connection signal="pressed" from="CommutePanel/CloseCommutePanelButton" to="." method="_on_close_commute_panel_button_pressed"]
+[connection signal="toggled" from="Quest/CheckButton" to="Quest" method="_on_check_button_toggled"]

--- a/game/main.gd
+++ b/game/main.gd
@@ -225,6 +225,8 @@ func _on_player_carry_action_requested(position: Vector2, actor_position: Vector
 				dropped_on_shipping_area = true
 			if dropped_on_shipping_area:
 				current_quest_progress = 100
+				net_worth += 100
+				$HUD.update_net_worth(net_worth)
 				DamageNumbers.money_number(100)
 				$HUD.update_quest_progress(current_quest_progress)
 		$Player.carrying_package = false

--- a/game/main.gd
+++ b/game/main.gd
@@ -39,6 +39,7 @@ func _on_player_furniture_placement_requested(position: Vector2) -> void:
 	if net_worth >= FURNITURE_COST:
 		net_worth -= FURNITURE_COST
 		$HUD.update_net_worth(net_worth)
+		DamageNumbers.money_number(-100)
 		$FurnitureContainer.create_furniture(position)
 
 func _on_day_timer_timeout() -> void:
@@ -60,6 +61,7 @@ func _on_day_timer_timeout() -> void:
 		else:
 			net_worth -= 5
 			$HUD.update_net_worth(net_worth)
+			DamageNumbers.money_number(-5)
 			drive_points += 1
 			$HUD.update_drive_points(drive_points)
 			DamageNumbers.display_number(1, $Player/NumberSpawn.global_position, true)
@@ -67,6 +69,7 @@ func _on_day_timer_timeout() -> void:
 func _on_mailman_package_collected() -> void:
 	net_worth += 10
 	$HUD.update_net_worth(net_worth)
+	DamageNumbers.money_number(10)
 
 
 func _on_hud_employee_recruited(recruited_employee: Enums.Employees) -> void:
@@ -91,6 +94,7 @@ func _on_hud_employee_fired(fired_employee: Enums.Employees) -> void:
 	var employee = employee_instances[fired_employee]
 	net_worth -= employee.money_owed
 	$HUD.update_net_worth(net_worth)
+	DamageNumbers.money_number(-employee.money_owed)
 	employee.queue_free()
 
 func _on_employee_money_owed_updated(money_owed, employee) -> void:
@@ -106,7 +110,9 @@ func _on_hud_employee_run_payroll_pressed(paid_employee: Enums.Employees) -> voi
 	var amount_to_pay = employee.money_owed
 	net_worth -= amount_to_pay
 	employee.pay(amount_to_pay)
+	
 	$HUD.update_net_worth(net_worth)
+	DamageNumbers.money_number(-amount_to_pay)
 
 func _on_player_widget_action_requested(position: Vector2, actor_position: Vector2) -> void:
 	if position.distance_to(actor_position) > 100:
@@ -202,6 +208,8 @@ func _on_player_coffee_vending_machine_placement_requested(position: Vector2) ->
 	if net_worth >= COFFEE_VENDING_MACHINE_COST:
 		net_worth -= COFFEE_VENDING_MACHINE_COST
 		$HUD.update_net_worth(net_worth)
+		DamageNumbers.money_number(-100)
+		
 		$CoffeeVendingMachineContainer.create_coffee_vending_machine(position)
 		$Player.in_coffee_zone = true
 
@@ -209,7 +217,7 @@ func _on_player_coffee_vending_machine_placement_requested(position: Vector2) ->
 func _on_player_carry_action_requested(position: Vector2, actor_position: Vector2) -> void:
 	if $Player.carrying_package && position.distance_to(actor_position) < 100:
 		$PackageContainer.create_package(position)
-		if current_quest_progress <= 100:
+		if current_quest_progress < 100:
 			var dropped_on_shipping_area = false
 			var tile_coord = $TileMapLayer.local_to_map($TileMapLayer.to_local(position))
 			var tile_data = $TileMapLayer.get_cell_tile_data(tile_coord)
@@ -217,6 +225,7 @@ func _on_player_carry_action_requested(position: Vector2, actor_position: Vector
 				dropped_on_shipping_area = true
 			if dropped_on_shipping_area:
 				current_quest_progress = 100
+				DamageNumbers.money_number(100)
 				$HUD.update_quest_progress(current_quest_progress)
 		$Player.carrying_package = false
 	else:

--- a/game/quest.gd
+++ b/game/quest.gd
@@ -2,3 +2,24 @@ extends Control
 
 func _on_check_button_toggled(toggled_on: bool) -> void:
 	$Collapsible.visible = toggled_on
+	
+func give_it_lil_wiggle() -> void:
+	var header = $Header
+	var header_start_y = $Header.position.y
+	var tween = get_tree().create_tween()
+	tween.set_parallel(true)
+	tween.tween_property(
+		header, "position:y", header_start_y + 24, 0.25
+	).set_ease(Tween.EASE_OUT)
+	tween.tween_property(
+		header, "position:y", header_start_y, 0.5
+	).set_ease(Tween.EASE_IN).set_delay(0.25)
+
+func _on_wiggle_timer_timeout() -> void:
+	var collapsed = !$Collapsible.visible
+	var displayed_progress = $Header/ProgressBar.value
+	if displayed_progress == 0.0 && collapsed:
+		give_it_lil_wiggle()
+
+func update_quest_progress(current_quest_progress: float) -> void:
+	$Header/ProgressBar.value = current_quest_progress

--- a/game/quest.gd
+++ b/game/quest.gd
@@ -1,0 +1,4 @@
+extends Control
+
+func _on_check_button_toggled(toggled_on: bool) -> void:
+	$Collapsible.visible = toggled_on

--- a/game/quest.gd
+++ b/game/quest.gd
@@ -26,6 +26,7 @@ func update_quest_progress(current_quest_progress: float) -> void:
 	$Header/ProgressBar.value = current_quest_progress
 	
 	if current_quest_progress == 100:
+		$Collapsible.visible = false
 		var header_start_y = header.position.y
 		var tween = get_tree().create_tween()
 		tween.set_parallel(true)

--- a/game/quest.gd
+++ b/game/quest.gd
@@ -1,11 +1,12 @@
 extends Control
 
+@onready var header = $Header
+
 func _on_check_button_toggled(toggled_on: bool) -> void:
 	$Collapsible.visible = toggled_on
 	
 func give_it_lil_wiggle() -> void:
-	var header = $Header
-	var header_start_y = $Header.position.y
+	var header_start_y = header.position.y
 	var tween = get_tree().create_tween()
 	tween.set_parallel(true)
 	tween.tween_property(
@@ -23,3 +24,17 @@ func _on_wiggle_timer_timeout() -> void:
 
 func update_quest_progress(current_quest_progress: float) -> void:
 	$Header/ProgressBar.value = current_quest_progress
+	
+	if current_quest_progress == 100:
+		var header_start_y = header.position.y
+		var tween = get_tree().create_tween()
+		tween.set_parallel(true)
+		tween.tween_property(
+			header, "position:y", header_start_y + 24, 0.25
+		).set_ease(Tween.EASE_OUT)
+		tween.tween_property(
+			header, "position:y", header_start_y, 0.5
+		).set_ease(Tween.EASE_IN).set_delay(0.25)
+		tween.tween_property(
+			header, "scale", Vector2.ZERO, 0.25
+		).set_ease(Tween.EASE_IN).set_delay(0.5)


### PR DESCRIPTION
Introduces a new little module in the top right that shows a preview of the current quest and its progress.

It shows a quest icon, a title, a progress bar, and a toggle icon.

<img width="661" alt="image" src="https://github.com/user-attachments/assets/ab5f61ac-9bbb-46b1-a15e-4082f7b4f1c9" />

-----

I give the quest component a little wiggle every 10 seconds if it's collapsed and the progress is at 0%.

Just a bit of a gentle nudge to focus the player.

-----

Expanding the component shows more detail on the quest in progress such as steps to be completed and the reward for doing so.

<img width="320" alt="image" src="https://github.com/user-attachments/assets/ce98012c-4846-438c-a704-7d80a1d75c64" />

-----

I've added one kind of hard coded quest to start which is building and shipping your first widget.

You get 25% progress attribute for completing each of the following steps:
* creating a widget
* progressing a widget to 100% build progress
* packaging a widget
* carrying and placing a widget on the shipping & receiving area

-----

Upon completion the quest component disappears with a little bit of an animation.

I've also introduced "money numbers" to make the $100 reward more obvious.

Now whenever you gain or lose money, there's an animation which is either red or green popping under your net worth total.

<img width="1176" alt="image" src="https://github.com/user-attachments/assets/403efda0-d7ab-4ccc-a1b5-21719db754fe" />
