### PR TITLE
[FP-767] Workbench build benefit

### DIFF
--- a/game/cursor_indicator.gd
+++ b/game/cursor_indicator.gd
@@ -40,8 +40,13 @@ func _process(_delta: float) -> void:
 	
 	if GameState.selected_action == Enums.Actions.WIDGET:
 		scale = Vector2(.5, .5)
+		var furniture = $"../FurnitureContainer".get_furniture_at_position(global_position)
+		if furniture != null:
+			global_position = furniture.global_position
 		if $"../WidgetContainer".is_buildable_position(global_position):
 			animation = "widget_placement"
+			if furniture != null:
+				global_position = global_position + Vector2(0, -20)
 		else:
 			animation = "widget_build"
 		

--- a/game/employee.gd
+++ b/game/employee.gd
@@ -73,7 +73,7 @@ func act(current_time: int) -> void:
 				
 				# Prefer workbench
 				for furniture in $"../../FurnitureContainer".get_children():
-					if work_area.distance_to(furniture.global_position) < 100:
+					if work_area.distance_to(furniture.global_position) < 100 && $"../../WidgetContainer".is_buildable_position(furniture.global_position):
 						work_area = furniture.global_position + Vector2(-50, 0)
 				
 				var world_space = get_world_2d().direct_space_state

--- a/game/employee.gd
+++ b/game/employee.gd
@@ -46,7 +46,8 @@ func act(current_time: int) -> void:
 		
 		if carrying_package:
 			if navigation_agent.is_navigation_finished():
-				if navigation_agent.distance_to_target() < 50:
+				var shipping_drop = $"../../EmployeeShippingDrop".global_position
+				if global_position.distance_to(shipping_drop) < 50:
 					$"../../PackageContainer".create_package(navigation_agent.target_position)
 					carrying_package = false
 				else:
@@ -121,7 +122,7 @@ func _physics_process(delta: float) -> void:
 		return
 	
 	if navigation_agent.is_navigation_finished():
-		print("navigation finished")
+		print(str(identity) + ": navigation finished")
 		walking_to_work_area = false
 		walking_to_commute_tile = false
 		return
@@ -142,12 +143,12 @@ func _on_navigation_agent_2d_velocity_computed(safe_velocity: Vector2) -> void:
 	
 	if global_position.distance_to(last_position) < movement_threshold:
 		if stuck_timer >= stuck_threshold_time:
-			print("Object is stuck!")
+			print(str(identity) + ": is stuck! Target reachable is " + str($NavigationAgent2D.is_target_reachable()))
 			
-			$NavigationAgent2D.target_position = global_position
+			#$NavigationAgent2D.target_position = global_position
 			var angle = randf_range(0, TAU)
 			var distance = randf_range(0, 1)
-			global_position = global_position + Vector2(cos(angle), sin(angle)) * 1
+			global_position = global_position + Vector2(cos(angle), sin(angle)) * 5
 			# handle the stuck case
 	else:
 		stuck_timer = 0.0

--- a/game/employee.tscn
+++ b/game/employee.tscn
@@ -61,6 +61,8 @@ rotation = 1.5708
 shape = SubResource("CircleShape2D_cojay")
 
 [node name="NavigationAgent2D" type="NavigationAgent2D" parent="."]
+path_desired_distance = 25.0
+target_desired_distance = 5.0
 avoidance_enabled = true
 radius = 20.0
 debug_enabled = true

--- a/game/furniture.gd
+++ b/game/furniture.gd
@@ -19,3 +19,11 @@ func _ready() -> void:
 func _notification(what): 
 	if what == NOTIFICATION_PREDELETE: 
 		obstacle_removed.emit(get_instance_id())
+
+func get_current_frame_rect() -> Rect2:
+	var animated_sprite = $AnimatedSprite2D
+	var size = animated_sprite.sprite_frames.get_frame_texture(animated_sprite.animation, animated_sprite.frame).get_size()
+	var pos = animated_sprite.offset
+	if animated_sprite.centered:
+		pos -= 0.5 * size
+	return Rect2(pos, size)

--- a/game/furniture.tscn
+++ b/game/furniture.tscn
@@ -3,15 +3,15 @@
 [ext_resource type="Script" path="res://furniture.gd" id="1_4r8bh"]
 [ext_resource type="Texture2D" uid="uid://dfxrfhliyxfcg" path="res://art/basic_workbench.png" id="1_ths7t"]
 
-[sub_resource type="SpriteFrames" id="SpriteFrames_nxxwv"]
+[sub_resource type="SpriteFrames" id="SpriteFrames_0v7qs"]
 animations = [{
 "frames": [{
 "duration": 1.0,
 "texture": ExtResource("1_ths7t")
 }],
 "loop": true,
-"name": &"idle",
-"speed": 3.0
+"name": &"default",
+"speed": 5.0
 }]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_dbnej"]
@@ -25,8 +25,7 @@ metadata/_edit_group_ = true
 
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
 scale = Vector2(0.75, 0.75)
-sprite_frames = SubResource("SpriteFrames_nxxwv")
-animation = &"idle"
+sprite_frames = SubResource("SpriteFrames_0v7qs")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 position = Vector2(0.5, 7.75)

--- a/game/furniture_container.gd
+++ b/game/furniture_container.gd
@@ -9,3 +9,23 @@ func create_furniture(desired_position: Vector2) -> void:
 	furniture.obstacle_added.connect(navigation_region.obstacle_added)
 	furniture.obstacle_removed.connect(navigation_region.obstacle_removed)
 	add_child(furniture)
+
+func get_furniture_at_position(selected_position: Vector2) -> Node2D:
+	for furniture in get_children():
+		var furniture_rect = furniture.get_current_frame_rect()
+		var check_rect = Rect2(furniture.to_local(selected_position), Vector2(1, 1))
+		
+		#var furniture_rect = Rect2(furniture.global_position, Vector2(65, 60))
+		#print(furniture_rect)
+		#var furniture_click_poly = furniture.get_node("ClickPoly") as Polygon2D
+		#print(selected_position)
+		#print(furniture_click_poly.polygon.to_global())
+		#if Geometry2D.is_point_in_polygon(selected_position, furniture_click_poly.polygon):
+			#print('furniture clicked')
+		#var check_rect = Rect2(selected_position, Vector2(1, 1))
+		#print(check_rect)
+		if furniture_rect.intersects(check_rect):
+			print('furniture clicked')
+			return furniture
+			
+	return null

--- a/game/furniture_container.gd
+++ b/game/furniture_container.gd
@@ -14,18 +14,8 @@ func get_furniture_at_position(selected_position: Vector2) -> Node2D:
 	for furniture in get_children():
 		var furniture_rect = furniture.get_current_frame_rect()
 		var check_rect = Rect2(furniture.to_local(selected_position), Vector2(1, 1))
-		
-		#var furniture_rect = Rect2(furniture.global_position, Vector2(65, 60))
-		#print(furniture_rect)
-		#var furniture_click_poly = furniture.get_node("ClickPoly") as Polygon2D
-		#print(selected_position)
-		#print(furniture_click_poly.polygon.to_global())
-		#if Geometry2D.is_point_in_polygon(selected_position, furniture_click_poly.polygon):
-			#print('furniture clicked')
-		#var check_rect = Rect2(selected_position, Vector2(1, 1))
-		#print(check_rect)
+
 		if furniture_rect.intersects(check_rect):
-			print('furniture clicked')
 			return furniture
-			
+
 	return null

--- a/game/main.gd
+++ b/game/main.gd
@@ -125,12 +125,15 @@ func _on_player_widget_action_requested(position: Vector2, actor_position: Vecto
 	var clicked_widget = $WidgetContainer.get_widget_at_position(position)
 	if clicked_widget != null && clicked_widget.progress < 100:
 		var max_build = 15 if drive_points > 0 else 1
-		var progress = randi_range(1, max_build )
+		if clicked_furniture:
+			max_build += 5
+		var progress = randi_range(1, max_build)
 		clicked_widget.build(progress)
 		if clicked_widget.progress == 100 && current_quest_progress <= 50:
 			current_quest_progress = 50
 			$HUD.update_quest_progress(current_quest_progress)
-		drive_points -= 1
+		if drive_points > 0:
+			drive_points -= 1
 		$HUD.update_drive_points(drive_points)
 
 	if $WidgetContainer.is_buildable_position(position):

--- a/game/main.gd
+++ b/game/main.gd
@@ -151,9 +151,17 @@ func _on_employee_widget_action_requested(position: Vector2, actor_position: Vec
 	if position.distance_to(actor_position) > 100:
 		return
 		
+	var clicked_furniture = $FurnitureContainer.get_furniture_at_position(position)
+	if clicked_furniture != null:
+		position = clicked_furniture.global_position + Vector2(0, -20)
+		
 	var clicked_widget = $WidgetContainer.get_widget_at_position(position)
 	if clicked_widget != null && clicked_widget.progress < 100:
-		clicked_widget.build(10)
+		var max_build = 10
+		if clicked_furniture:
+			max_build += 5
+		var progress = randi_range(1, max_build)
+		clicked_widget.build(progress)
 
 	if $WidgetContainer.is_buildable_position(position):
 		$WidgetContainer.create_widget(position)

--- a/game/main.gd
+++ b/game/main.gd
@@ -120,8 +120,7 @@ func _on_player_widget_action_requested(position: Vector2, actor_position: Vecto
 		
 	var clicked_furniture = $FurnitureContainer.get_furniture_at_position(position)
 	if clicked_furniture != null:
-		
-		return
+		position = clicked_furniture.global_position + Vector2(0, -20)
 		
 	var clicked_widget = $WidgetContainer.get_widget_at_position(position)
 	if clicked_widget != null && clicked_widget.progress < 100:
@@ -136,6 +135,9 @@ func _on_player_widget_action_requested(position: Vector2, actor_position: Vecto
 
 	if $WidgetContainer.is_buildable_position(position):
 		$WidgetContainer.create_widget(position)
+		if clicked_furniture != null:
+			var new_widget = $WidgetContainer.get_widget_at_position(position)
+			new_widget.z_index = 1
 		if current_quest_progress <= 25:
 			current_quest_progress = 25
 			$HUD.update_quest_progress(current_quest_progress)
@@ -192,7 +194,7 @@ func _on_hud_player_rest_requested() -> void:
 func _on_player_package_widget_requested(position: Vector2, actor_position: Vector2) -> void:
 	if position.distance_to(actor_position) > 100:
 		return
-		
+
 	for widget in $WidgetContainer.get_children():
 		var collision_shape = widget.get_node("CollisionShape2D") as CollisionShape2D
 		var circle = collision_shape.shape as CircleShape2D

--- a/game/main.gd
+++ b/game/main.gd
@@ -118,6 +118,11 @@ func _on_player_widget_action_requested(position: Vector2, actor_position: Vecto
 	if position.distance_to(actor_position) > 100:
 		return
 		
+	var clicked_furniture = $FurnitureContainer.get_furniture_at_position(position)
+	if clicked_furniture != null:
+		
+		return
+		
 	var clicked_widget = $WidgetContainer.get_widget_at_position(position)
 	if clicked_widget != null && clicked_widget.progress < 100:
 		var max_build = 15 if drive_points > 0 else 1

--- a/game/main.tscn
+++ b/game/main.tscn
@@ -260,7 +260,7 @@ scale = Vector2(0.75, 0.75)
 sprite_frames = SubResource("SpriteFrames_i8n55")
 
 [node name="CursorIndicator" type="AnimatedSprite2D" parent="."]
-z_index = 1
+z_index = 2
 sprite_frames = SubResource("SpriteFrames_hsts8")
 animation = &"coffee_vending_machine_invalid"
 script = ExtResource("11_j04ey")

--- a/game/package.gd
+++ b/game/package.gd
@@ -1,3 +1,5 @@
+class_name Package
+
 extends RigidBody2D
 
 signal obstacle_added(obstacle_id :int, obstructed_area: Polygon2D)

--- a/game/package_container.gd
+++ b/game/package_container.gd
@@ -20,5 +20,3 @@ func create_package(desired_position: Vector2) -> void:
 	var on_furniture = $"../FurnitureContainer".get_furniture_at_position(desired_position)
 	if on_furniture:
 		package.z_index = 1
-	
-	return

--- a/game/package_container.gd
+++ b/game/package_container.gd
@@ -16,3 +16,9 @@ func create_package(desired_position: Vector2) -> void:
 	package.obstacle_added.connect(navigation_region.obstacle_added)
 	package.obstacle_removed.connect(navigation_region.obstacle_removed)
 	add_child(package)
+	
+	var on_furniture = $"../FurnitureContainer".get_furniture_at_position(desired_position)
+	if on_furniture:
+		package.z_index = 1
+	
+	return

--- a/game/widget_container.gd
+++ b/game/widget_container.gd
@@ -35,3 +35,7 @@ func create_widget(desired_position: Vector2) -> void:
 	widget.obstacle_added.connect(navigation_region.obstacle_added)
 	widget.obstacle_removed.connect(navigation_region.obstacle_removed)
 	add_child(widget)
+	
+	var on_furniture = $"../FurnitureContainer".get_furniture_at_position(desired_position)
+	if on_furniture:
+		widget.z_index = 1


### PR DESCRIPTION
When you have the build / progress widget action selected, your cursor will snap to a workbench if one is present.

<img width="307" alt="image" src="https://github.com/user-attachments/assets/1c70c4b7-6343-4920-be15-5587a6e513b1" />

-----

Workbenches give a +5 to the max progress while building widgets. A max of 15 for employees and a max of 20 for the player.

<img width="253" alt="image" src="https://github.com/user-attachments/assets/f9d2e647-3370-42f2-8ae8-425a29727c76" />

-----

Did a number of things to tweak employee behaviors to keep them from crowding the same bench, getting stuck, or standing around making no progress.

<img width="1174" alt="image" src="https://github.com/user-attachments/assets/531d5f81-41a7-4922-8f59-a2912be2adf5" />
