### PR TITLE
[FP-768] Employee work areas

### DIFF
--- a/game/employee.gd
+++ b/game/employee.gd
@@ -26,6 +26,8 @@ var stuck_threshold_time := 1.0 # seconds
 var movement_threshold := 5.0 # pixels
 
 @onready var navigation_agent: NavigationAgent2D = $NavigationAgent2D
+@onready var default_work_area: Marker2D =  $"../../EmployeeWorkArea"
+@onready var preferred_work_area: Marker2D = null
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
@@ -59,7 +61,7 @@ func act(current_time: int) -> void:
 				return
 
 		# Try to get to specified work area.
-		var work_area = $"../../EmployeeWorkArea".global_position
+		var work_area = get_current_work_area()
 		#print(str(identity) + ': distance to work area ' + str(global_position.distance_to(work_area)))
 		if global_position.distance_to(work_area) > 100 || building_failed_in_current_work_area:
 			if walking_to_work_area:
@@ -223,3 +225,17 @@ func set_shipping_drop_destination() -> void:
 	shipping_drop = shipping_drop + Vector2(cos(angle), sin(angle)) * distance
 	if global_position.distance_to(shipping_drop) > 50:
 		$NavigationAgent2D.target_position = shipping_drop
+
+func assign_work_area(desired_position: Vector2) -> void:
+	if preferred_work_area != null:
+		preferred_work_area.queue_free()
+	
+	var new_work_area = Marker2D.new()
+	new_work_area.global_position = desired_position
+	preferred_work_area = new_work_area
+	
+func get_current_work_area() -> Vector2:
+	if preferred_work_area != null:
+		return preferred_work_area.global_position
+	else:
+		return default_work_area.global_position

--- a/game/hud.gd
+++ b/game/hud.gd
@@ -8,6 +8,7 @@ signal employee_run_payroll_pressed(employee: Enums.Employees)
 signal accelerate_time_pressed(irl_seconds_per_5_min: float)
 signal overlaying_panel_visibility_changed(overlaying_panel_visible: bool)
 signal player_rest_requested
+signal employee_work_area_assigned(employee: Enums.Employees)
 
 enum AccelerateTimeOptions {
 	DEFAULT = 0,
@@ -181,3 +182,11 @@ func _on_fire_carry_button_pressed() -> void:
 
 func update_quest_progress(current_quest_progress: float) -> void:
 	$Quest.update_quest_progress(current_quest_progress)
+
+
+func _on_assign_colm_work_area_pressed() -> void:
+	employee_work_area_assigned.emit(Enums.Employees.COLM)
+
+
+func _on_assign_carry_work_area_pressed() -> void:
+	employee_work_area_assigned.emit(Enums.Employees.CARRY)

--- a/game/hud.gd
+++ b/game/hud.gd
@@ -126,6 +126,8 @@ func _ready() -> void:
 	$TopBarBackground.visible = false
 	visible = true
 	$Quest.visible = false
+	$HRPanel/TabContainer/Employees/Employee.visible = false
+	$HRPanel/TabContainer/Employees/EmployeeCarry.visible = false
 
 func update_drive_points(drive_points) -> void:
 	$DriveProgressBar.visible = true

--- a/game/hud.tscn
+++ b/game/hud.tscn
@@ -336,7 +336,6 @@ layout_mode = 2
 metadata/_tab_index = 1
 
 [node name="Employee" type="HBoxContainer" parent="HRPanel/TabContainer/Employees"]
-visible = false
 layout_mode = 0
 offset_right = 449.0
 offset_bottom = 224.0
@@ -369,12 +368,15 @@ text = "Run Payroll ($0)"
 layout_mode = 2
 text = "Fire"
 
+[node name="AssignColmWorkArea" type="Button" parent="HRPanel/TabContainer/Employees/Employee/VBoxContainer"]
+layout_mode = 2
+text = "Assign Work Area"
+
 [node name="EmployeeCarry" type="HBoxContainer" parent="HRPanel/TabContainer/Employees"]
-visible = false
 layout_mode = 0
-offset_top = 158.0
+offset_top = 190.0
 offset_right = 449.0
-offset_bottom = 382.0
+offset_bottom = 414.0
 
 [node name="TextureRect" type="TextureRect" parent="HRPanel/TabContainer/Employees/EmployeeCarry"]
 layout_mode = 2
@@ -404,6 +406,10 @@ text = "Run Payroll ($0)"
 [node name="FireCarryButton" type="Button" parent="HRPanel/TabContainer/Employees/EmployeeCarry/VBoxContainer"]
 layout_mode = 2
 text = "Fire"
+
+[node name="AssignCarryWorkArea" type="Button" parent="HRPanel/TabContainer/Employees/EmployeeCarry/VBoxContainer"]
+layout_mode = 2
+text = "Assign Work Area"
 
 [node name="AccelerateTimeButton" type="Button" parent="."]
 anchors_preset = 1
@@ -563,8 +569,10 @@ autowrap_mode = 3
 [connection signal="pressed" from="HRPanel/TabContainer/Recruiting/RecruitCarry" to="." method="_on_recruit_carry_pressed"]
 [connection signal="pressed" from="HRPanel/TabContainer/Employees/Employee/VBoxContainer/RunPayrollButton" to="." method="_on_run_payroll_button_pressed"]
 [connection signal="pressed" from="HRPanel/TabContainer/Employees/Employee/VBoxContainer/FireButton" to="." method="_on_fire_button_pressed"]
+[connection signal="pressed" from="HRPanel/TabContainer/Employees/Employee/VBoxContainer/AssignColmWorkArea" to="." method="_on_assign_colm_work_area_pressed"]
 [connection signal="pressed" from="HRPanel/TabContainer/Employees/EmployeeCarry/VBoxContainer/RunPayrollCarryButton" to="." method="_on_run_payroll_carry_button_pressed"]
 [connection signal="pressed" from="HRPanel/TabContainer/Employees/EmployeeCarry/VBoxContainer/FireCarryButton" to="." method="_on_fire_carry_button_pressed"]
+[connection signal="pressed" from="HRPanel/TabContainer/Employees/EmployeeCarry/VBoxContainer/AssignCarryWorkArea" to="." method="_on_assign_carry_work_area_pressed"]
 [connection signal="pressed" from="AccelerateTimeButton" to="." method="_on_accelerate_time_pressed"]
 [connection signal="visibility_changed" from="CommutePanel" to="." method="_on_commute_panel_visibility_changed"]
 [connection signal="pressed" from="CommutePanel/RestButton" to="." method="_on_rest_button_pressed"]

--- a/game/hud.tscn
+++ b/game/hud.tscn
@@ -139,26 +139,6 @@ theme_override_font_sizes/font_size = 32
 horizontal_alignment = 1
 vertical_alignment = 1
 
-[node name="Message" type="Label" parent="."]
-anchors_preset = 8
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
-offset_left = -240.0
-offset_top = -120.0
-offset_right = 240.0
-offset_bottom = 120.0
-grow_horizontal = 2
-grow_vertical = 2
-theme_override_fonts/font = ExtResource("1_3xhbu")
-theme_override_font_sizes/font_size = 64
-text = "Office
-Sim"
-horizontal_alignment = 1
-vertical_alignment = 1
-autowrap_mode = 2
-
 [node name="StartButton" type="Button" parent="."]
 anchors_preset = 7
 anchor_left = 0.5
@@ -554,6 +534,26 @@ text = "* Create a widget
 Reward:
 $100"
 autowrap_mode = 3
+
+[node name="Message" type="Label" parent="."]
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -240.0
+offset_top = -120.0
+offset_right = 240.0
+offset_bottom = 120.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_fonts/font = ExtResource("1_3xhbu")
+theme_override_font_sizes/font_size = 64
+text = "Office
+Sim"
+horizontal_alignment = 1
+vertical_alignment = 1
+autowrap_mode = 2
 
 [connection signal="action_bar_button_pressed" from="." to="HRPanel" method="_on_hud_action_bar_button_pressed"]
 [connection signal="pressed" from="StartButton" to="." method="_on_start_button_pressed"]

--- a/game/main.gd
+++ b/game/main.gd
@@ -272,3 +272,4 @@ func _on_player_carry_action_requested(position: Vector2, actor_position: Vector
 func _on_hud_employee_work_area_assigned(assigned_employee: Enums.Employees) -> void:
 	var employee = employee_instances[assigned_employee]
 	employee.assign_work_area($Player.global_position)
+	$HUD.show_message("Assigned to player's current position.")

--- a/game/main.gd
+++ b/game/main.gd
@@ -267,3 +267,8 @@ func _on_player_carry_action_requested(position: Vector2, actor_position: Vector
 			$Player.carrying_package = true
 			package.queue_free()
 			return
+
+
+func _on_hud_employee_work_area_assigned(assigned_employee: Enums.Employees) -> void:
+	var employee = employee_instances[assigned_employee]
+	employee.assign_work_area($Player.global_position)

--- a/game/main.tscn
+++ b/game/main.tscn
@@ -294,6 +294,7 @@ position = Vector2(928, 432)
 [connection signal="employee_fired" from="HUD" to="." method="_on_hud_employee_fired"]
 [connection signal="employee_recruited" from="HUD" to="." method="_on_hud_employee_recruited"]
 [connection signal="employee_run_payroll_pressed" from="HUD" to="." method="_on_hud_employee_run_payroll_pressed"]
+[connection signal="employee_work_area_assigned" from="HUD" to="." method="_on_hud_employee_work_area_assigned"]
 [connection signal="overlaying_panel_visibility_changed" from="HUD" to="." method="_on_hud_overlaying_panel_visibility_changed"]
 [connection signal="player_rest_requested" from="HUD" to="." method="_on_hud_player_rest_requested"]
 [connection signal="start_game" from="HUD" to="." method="new_game"]


### PR DESCRIPTION
This adds a new button to the employees tab which assigns the employee's location to the current position of the player.

<img width="1056" alt="image" src="https://github.com/user-attachments/assets/1146f64b-4b2d-401a-a756-23f6e5f7199d" />

-----

So now you can start to create some orderly offices where everyone has their own spot.

<img width="984" alt="image" src="https://github.com/user-attachments/assets/8537329d-329b-4578-b247-dbf453850d1b" />
